### PR TITLE
:sparkles: Add OIDC Discovery endpoint and unified config

### DIFF
--- a/core/src/main/kotlin/party/morino/mineauth/core/file/data/MineAuthConfig.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/file/data/MineAuthConfig.kt
@@ -1,0 +1,68 @@
+package party.morino.mineauth.core.file.data
+
+import kotlinx.serialization.Serializable
+import party.morino.mineauth.api.utils.UUIDSerializer
+import java.util.*
+
+/**
+ * MineAuth 統合設定ファイル
+ * Issue #66: 複数の設定ファイルを1つにまとめる
+ *
+ * 設定ファイルパス: plugins/MineAuth/config.json
+ */
+@Serializable
+data class MineAuthConfig(
+    // サーバー設定
+    val server: ServerConfig = ServerConfig(),
+
+    // JWT/OIDC設定
+    val jwt: JwtConfig = JwtConfig(),
+
+    // OAuth設定
+    val oauth: OAuthConfig = OAuthConfig()
+)
+
+/**
+ * サーバー設定
+ */
+@Serializable
+data class ServerConfig(
+    // 外部公開URL（OIDC Discoveryなどで使用）
+    val baseUrl: String = "https://api.example.com",
+
+    // HTTPサーバーポート
+    val port: Int = 8080,
+
+    // SSL設定（nullの場合はHTTPのみ）
+    val ssl: SSLConfigData? = null
+)
+
+/**
+ * JWT/OIDC設定
+ */
+@Serializable
+data class JwtConfig(
+    // JWTのissuer（通常はbaseUrlと同じ）
+    val issuer: String = "https://api.example.com",
+
+    // JWTのrealm
+    val realm: String = "example.com",
+
+    // 秘密鍵ファイル名（pluginsDir相対）
+    val privateKeyFile: String = "privateKey.pem",
+
+    // JWKのキーID
+    val keyId: @Serializable(with = UUIDSerializer::class) UUID = UUID.randomUUID()
+)
+
+/**
+ * OAuth設定
+ */
+@Serializable
+data class OAuthConfig(
+    // 認可画面に表示するアプリケーション名
+    val applicationName: String = "MineAuth",
+
+    // 認可画面に表示するロゴURL
+    val logoUrl: String = "/assets/lock.svg"
+)

--- a/core/src/main/kotlin/party/morino/mineauth/core/file/load/config/ConfigLoader.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/file/load/config/ConfigLoader.kt
@@ -1,0 +1,76 @@
+package party.morino.mineauth.core.file.load.config
+
+import kotlinx.serialization.encodeToString
+import org.koin.core.context.loadKoinModules
+import org.koin.dsl.module
+import party.morino.mineauth.api.utils.json
+import party.morino.mineauth.core.file.data.JWTConfigData
+import party.morino.mineauth.core.file.data.MineAuthConfig
+import party.morino.mineauth.core.file.data.OAuthConfigData
+import party.morino.mineauth.core.file.data.WebServerConfigData
+import java.io.File
+
+/**
+ * 統合設定ファイルローダー
+ * Issue #66: 複数の設定ファイルを1つにまとめる
+ *
+ * plugins/MineAuth/config.json を読み込み、
+ * 後方互換性のために各データクラスにも変換してKoinに登録する
+ */
+class ConfigLoader : AbstractConfigLoader() {
+    override val configFile: File = plugin.dataFolder.resolve("config.json")
+
+    override fun load() {
+        // 設定ファイルが存在しない場合はデフォルト値で作成
+        if (!configFile.exists()) {
+            plugin.logger.info("config.json not found. Creating new one.")
+            configFile.parentFile.mkdirs()
+            configFile.createNewFile()
+            val defaultConfig = MineAuthConfig()
+            configFile.writeText(json.encodeToString(defaultConfig))
+        }
+
+        val config: MineAuthConfig = json.decodeFromString(configFile.readText())
+
+        // 統合設定をKoinに登録
+        loadKoinModules(module {
+            single { config }
+        })
+
+        // 後方互換性: 既存のデータクラスにも変換して登録
+        loadLegacyModules(config)
+    }
+
+    /**
+     * 後方互換性のために既存のデータクラスに変換してKoinに登録
+     * 既存コードが JWTConfigData, OAuthConfigData, WebServerConfigData を
+     * 直接injectしている場合でも動作するようにする
+     */
+    private fun loadLegacyModules(config: MineAuthConfig) {
+        // JWTConfigData への変換
+        val jwtConfigData = JWTConfigData(
+            issuer = config.jwt.issuer,
+            realm = config.jwt.realm,
+            privateKeyFile = config.jwt.privateKeyFile,
+            keyId = config.jwt.keyId
+        )
+
+        // OAuthConfigData への変換
+        val oauthConfigData = OAuthConfigData(
+            applicationName = config.oauth.applicationName,
+            logoUrl = config.oauth.logoUrl
+        )
+
+        // WebServerConfigData への変換
+        val webServerConfigData = WebServerConfigData(
+            port = config.server.port,
+            ssl = config.server.ssl
+        )
+
+        loadKoinModules(module {
+            single { jwtConfigData }
+            single { oauthConfigData }
+            single { webServerConfigData }
+        })
+    }
+}

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/components/auth/OIDCDiscoveryResponse.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/components/auth/OIDCDiscoveryResponse.kt
@@ -1,0 +1,107 @@
+package party.morino.mineauth.core.web.components.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * OpenID Connect Discovery Response
+ * OpenID Connect Discovery 1.0 準拠
+ *
+ * @see https://openid.net/specs/openid-connect-discovery-1_0.html
+ */
+@Serializable
+data class OIDCDiscoveryResponse(
+    // 必須: Issuer Identifier
+    val issuer: String,
+
+    // 必須: Authorization Endpoint
+    @SerialName("authorization_endpoint")
+    val authorizationEndpoint: String,
+
+    // 必須: Token Endpoint
+    @SerialName("token_endpoint")
+    val tokenEndpoint: String,
+
+    // 推奨: UserInfo Endpoint
+    @SerialName("userinfo_endpoint")
+    val userinfoEndpoint: String,
+
+    // 必須: JWKs URI
+    @SerialName("jwks_uri")
+    val jwksUri: String,
+
+    // 必須: サポートするレスポンスタイプ
+    @SerialName("response_types_supported")
+    val responseTypesSupported: List<String>,
+
+    // 必須: サポートするサブジェクトタイプ
+    @SerialName("subject_types_supported")
+    val subjectTypesSupported: List<String>,
+
+    // 必須: IDトークンの署名アルゴリズム
+    @SerialName("id_token_signing_alg_values_supported")
+    val idTokenSigningAlgValuesSupported: List<String>,
+
+    // 推奨: サポートするスコープ
+    @SerialName("scopes_supported")
+    val scopesSupported: List<String>,
+
+    // 推奨: トークンエンドポイントの認証方法
+    @SerialName("token_endpoint_auth_methods_supported")
+    val tokenEndpointAuthMethodsSupported: List<String>,
+
+    // 推奨: サポートするクレーム
+    @SerialName("claims_supported")
+    val claimsSupported: List<String>,
+
+    // 推奨: サポートするグラントタイプ
+    @SerialName("grant_types_supported")
+    val grantTypesSupported: List<String>,
+
+    // 推奨: コードチャレンジメソッド（PKCE）
+    @SerialName("code_challenge_methods_supported")
+    val codeChallengeMethodsSupported: List<String>
+) {
+    companion object {
+        /**
+         * baseUrlからOIDC Discoveryレスポンスを生成
+         */
+        fun fromBaseUrl(baseUrl: String): OIDCDiscoveryResponse {
+            val normalizedUrl = baseUrl.trimEnd('/')
+
+            return OIDCDiscoveryResponse(
+                issuer = normalizedUrl,
+                authorizationEndpoint = "$normalizedUrl/oauth2/authorize",
+                tokenEndpoint = "$normalizedUrl/oauth2/token",
+                userinfoEndpoint = "$normalizedUrl/oauth2/userinfo",
+                jwksUri = "$normalizedUrl/.well-known/jwks.json",
+                responseTypesSupported = listOf("code"),
+                subjectTypesSupported = listOf("public"),
+                idTokenSigningAlgValuesSupported = listOf("RS256"),
+                scopesSupported = listOf("openid", "profile"),
+                tokenEndpointAuthMethodsSupported = listOf(
+                    "client_secret_post",
+                    "none"
+                ),
+                claimsSupported = listOf(
+                    "sub",
+                    "name",
+                    "nickname",
+                    "picture",
+                    "iss",
+                    "aud",
+                    "exp",
+                    "iat",
+                    "auth_time",
+                    "nonce",
+                    "at_hash"
+                ),
+                grantTypesSupported = listOf(
+                    "authorization_code",
+                    "refresh_token"
+                ),
+                codeChallengeMethodsSupported = listOf("S256")
+            )
+        }
+    }
+}

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/WellKnownRouter.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/WellKnownRouter.kt
@@ -1,14 +1,40 @@
 package party.morino.mineauth.core.web.router.auth
 
-import io.ktor.server.http.content.*
+import io.ktor.http.*
+import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import party.morino.mineauth.core.MineAuth
+import party.morino.mineauth.core.file.data.MineAuthConfig
+import party.morino.mineauth.core.file.utils.KeyUtils
+import party.morino.mineauth.core.web.components.auth.OIDCDiscoveryResponse
 
-object WellKnownRouter: KoinComponent {
-    private val plugin: MineAuth by inject()
+/**
+ * .well-known エンドポイント
+ * OIDC Discovery と JWKs を提供
+ */
+object WellKnownRouter : KoinComponent {
+    private val config: MineAuthConfig by inject()
+
     fun Route.wellKnownRouter() {
-        staticFiles(".well-known", plugin.dataFolder, "jwks.json")
+        route(".well-known") {
+            // OIDC Discovery Endpoint
+            // OpenID Connect Discovery 1.0 準拠
+            get("openid-configuration") {
+                val response = OIDCDiscoveryResponse.fromBaseUrl(config.server.baseUrl)
+                call.respond(response)
+            }
+
+            // JWKs Endpoint
+            // RFC 7517 準拠の JWK Set を返す
+            get("jwks.json") {
+                val jwksFile = KeyUtils.generatedDir.resolve("jwks.json")
+                if (jwksFile.exists()) {
+                    call.respondText(jwksFile.readText(), ContentType.Application.Json)
+                } else {
+                    call.respond(HttpStatusCode.NotFound)
+                }
+            }
+        }
     }
 }

--- a/docs/docs/administrator/config.md
+++ b/docs/docs/administrator/config.md
@@ -1,26 +1,83 @@
 # ⚙️ Configuration
 
+MineAuthでは、プラグインの設定を`plugins/MineAuth/config.json`ファイルで管理します。
+
+## 📁 ファイル構成
+
+設定ファイルは`plugins/MineAuth/`ディレクトリに配置されます。
+
+```
+plugins/MineAuth/
+├── config.json          # メイン設定ファイル
+├── clients.json         # OAuthクライアント設定
+└── generated/           # 自動生成ファイル
+    ├── privateKey.pem   # RSA秘密鍵
+    ├── publicKey.pem    # RSA公開鍵
+    ├── certificate.pem  # X.509証明書
+    └── jwks.json        # JWK Set
+```
+
+## ⚙️ config.json
+
 ```json5
 {
-  "jwt": {
-    "issuer": "https://api.example.com/", //if you use proxy, you should set proxy url like "https://api.example.com/lobby" 
-    "realm": "example.com",
-    "privateKeyFile": "privateKey.pem",
-    "keyId": " a22c063-a708-c801-6f92-49f6d53b89b2"
-  },
-  "oauth" : {
-    "applicationName": "MineAuth",
-    "logoUrl": "/main/assets/lock.svg"
-  },
-  "webServer": {
+  "server": {
+    "baseUrl": "https://api.example.com",  // OIDCのissuerおよびエンドポイントのベースURL
     "port": 8080,
     "ssl": {
       "sslPort": 8443,
       "keyStore": "keystore.jks",
       "keyAlias": "MineAuth",
       "keyStorePassword": "password",
-      "privateKeyPassword" : "password"
-    } // if you don't need ssl, you can remove this and set null.
+      "privateKeyPassword": "password"
+    } // SSLが不要な場合はnullまたは省略可能
+  },
+  "jwt": {
+    "issuer": "https://api.example.com/",  // JWTトークンの発行者
+    "realm": "example.com",
+    "privateKeyFile": "privateKey.pem",
+    "keyId": "a22c063a-a708-c801-6f92-49f6d53b89b2"  // JWKのキーID
+  },
+  "oauth": {
+    "applicationName": "MineAuth",  // 認可画面に表示されるアプリケーション名
+    "logoUrl": "/assets/lock.svg"   // 認可画面に表示されるロゴURL
   }
 }
 ```
+
+### 📝 設定項目の説明
+
+#### server
+
+| キー | 型 | 必須 | 説明 |
+|------|------|------|------|
+| `baseUrl` | string | ✅ | OIDC Discoveryで公開されるエンドポイントのベースURL。リバースプロキシを使用する場合はプロキシのURLを設定してください |
+| `port` | number | ✅ | HTTPサーバーのポート番号 |
+| `ssl` | object | ❌ | SSL設定（省略可能） |
+
+#### jwt
+
+| キー | 型 | 必須 | 説明 |
+|------|------|------|------|
+| `issuer` | string | ✅ | JWTトークンの発行者識別子 |
+| `realm` | string | ✅ | JWT認証のレルム名 |
+| `privateKeyFile` | string | ✅ | 秘密鍵ファイルのパス（generated/からの相対パス） |
+| `keyId` | string | ✅ | JWKのキーID（UUID形式） |
+
+#### oauth
+
+| キー | 型 | 必須 | 説明 |
+|------|------|------|------|
+| `applicationName` | string | ✅ | OAuth認可画面に表示されるアプリケーション名 |
+| `logoUrl` | string | ✅ | OAuth認可画面に表示されるロゴのURL |
+
+## 🔐 自動生成ファイル
+
+`generated/`ディレクトリには、プラグインが自動的に生成する暗号鍵と証明書が配置されます。
+
+- **privateKey.pem**: RS256署名に使用するRSA秘密鍵
+- **publicKey.pem**: RSA公開鍵
+- **certificate.pem**: 自己署名X.509証明書
+- **jwks.json**: JWK Set（公開鍵をJSON Web Key形式で公開）
+
+これらのファイルは初回起動時に自動生成されます。削除した場合は再生成されますが、既存のトークンは無効になります。

--- a/docs/docs/contributer/endpoint.md
+++ b/docs/docs/contributer/endpoint.md
@@ -59,10 +59,10 @@ This is an endpoint list for OAuth2.0 and OpenID Connect (OIDC) for Moripa API.
   </thead>
   <tbody>
     <tr>
-      <td>❌</td>
+      <td>✅</td>
       <td>Discovery</td>
       <td><code>/.well-known/openid-configuration</code></td>
-      <td>-</td>
+      <td><a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OIDC Discovery 1.0</a></td>
     </tr>
     <tr>
       <td>✅</td>

--- a/docs/docs/developer/oauth/discovery.md
+++ b/docs/docs/developer/oauth/discovery.md
@@ -1,0 +1,84 @@
+---
+sidebar_position: 1
+---
+
+# 🔍 OIDC Discovery
+
+MineAuthは、[OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html)に準拠したDiscoveryエンドポイントを提供します。
+
+## 📍 エンドポイント
+
+```
+GET /.well-known/openid-configuration
+```
+
+## 📋 レスポンス例
+
+```json
+{
+  "issuer": "https://api.example.com",
+  "authorization_endpoint": "https://api.example.com/oauth2/authorize",
+  "token_endpoint": "https://api.example.com/oauth2/token",
+  "userinfo_endpoint": "https://api.example.com/oauth2/userinfo",
+  "jwks_uri": "https://api.example.com/.well-known/jwks.json",
+  "response_types_supported": ["code"],
+  "subject_types_supported": ["public"],
+  "id_token_signing_alg_values_supported": ["RS256"],
+  "scopes_supported": ["openid", "profile"],
+  "token_endpoint_auth_methods_supported": ["client_secret_post", "none"],
+  "claims_supported": [
+    "sub",
+    "name",
+    "nickname",
+    "picture",
+    "iss",
+    "aud",
+    "exp",
+    "iat",
+    "auth_time",
+    "nonce",
+    "at_hash"
+  ],
+  "grant_types_supported": ["authorization_code", "refresh_token"],
+  "code_challenge_methods_supported": ["S256"]
+}
+```
+
+## 🔑 メタデータの説明
+
+| フィールド | 説明 |
+|------------|------|
+| `issuer` | トークンの発行者識別子 |
+| `authorization_endpoint` | 認可エンドポイントのURL |
+| `token_endpoint` | トークンエンドポイントのURL |
+| `userinfo_endpoint` | UserInfoエンドポイントのURL |
+| `jwks_uri` | JWK SetのURL（公開鍵の取得先） |
+| `response_types_supported` | サポートするレスポンスタイプ |
+| `subject_types_supported` | サポートするサブジェクトタイプ |
+| `id_token_signing_alg_values_supported` | IDトークンの署名アルゴリズム |
+| `scopes_supported` | サポートするスコープ |
+| `token_endpoint_auth_methods_supported` | トークンエンドポイントの認証方法 |
+| `claims_supported` | サポートするクレーム |
+| `grant_types_supported` | サポートするグラントタイプ |
+| `code_challenge_methods_supported` | PKCEで使用可能なコードチャレンジメソッド |
+
+## ⚙️ 設定
+
+Discoveryで公開されるURLは、`config.json`の`server.baseUrl`から生成されます。
+
+```json
+{
+  "server": {
+    "baseUrl": "https://api.example.com"
+  }
+}
+```
+
+リバースプロキシを使用している場合は、プロキシのURLを設定してください。
+
+## 🔗 関連エンドポイント
+
+- **JWKs**: `/.well-known/jwks.json` - 公開鍵の取得
+- **Authorization**: `/oauth2/authorize` - 認可リクエスト
+- **Token**: `/oauth2/token` - トークン発行
+- **UserInfo**: `/oauth2/userinfo` - ユーザー情報の取得


### PR DESCRIPTION
## Summary

- Implement OIDC Discovery endpoint (`/.well-known/openid-configuration`) compliant with [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html)
- Consolidate multiple config files (`jwt.json`, `oauth.json`, `web-server.json`) into single `config.json`
- Move generated files (privateKey.pem, publicKey.pem, certificate.pem, jwks.json) to `plugins/MineAuth/generated/` directory
- Add `baseUrl` configuration for dynamic OIDC endpoint generation

## Changes

### New Files
- `MineAuthConfig.kt` - Unified configuration data class with `ServerConfig`, `JwtConfig`, `OAuthConfig`
- `ConfigLoader.kt` - Loads unified config with backward compatibility for legacy data classes
- `OIDCDiscoveryResponse.kt` - OIDC Discovery metadata response

### Modified Files
- `FileUtils.kt` - Updated loading order (ConfigLoader first, then KeyUtils)
- `KeyUtils.kt` - Changed to use `generated/` directory for all generated files
- `WellKnownRouter.kt` - Added OIDC Discovery endpoint

### Documentation
- Updated `config.md` with new config structure
- Updated `endpoint.md` to mark Discovery as implemented
- Added `discovery.md` for OIDC Discovery documentation

## Related Issues

Closes #186 (OIDC Discovery endpoint)
Closes #66 (Consolidate config files)

## Test plan

- [ ] Verify `/.well-known/openid-configuration` returns valid OIDC metadata
- [ ] Verify `baseUrl` from config is correctly used in endpoint URLs
- [ ] Verify generated files are placed in `generated/` directory
- [ ] Verify backward compatibility with existing code using legacy config classes