### PR TITLE
✨ Add email claim support to OIDC userinfo

### DIFF
--- a/core/src/main/kotlin/party/morino/mineauth/core/file/data/MineAuthConfig.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/file/data/MineAuthConfig.kt
@@ -37,7 +37,12 @@ data class ServerConfig(
     val port: Int = 8080,
 
     // SSL設定（nullの場合はHTTPのみ）
-    val ssl: SSLConfigData? = null
+    val ssl: SSLConfigData? = null,
+
+    // OIDC email クレーム用フォーマット（nullの場合はemailクレームを返さない）
+    // プレースホルダー: <uuid>, <username>
+    // 例: "<uuid>-<username>@example.com"
+    val emailFormat: String? = null
 )
 
 /**

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/components/auth/OIDCDiscoveryResponse.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/components/auth/OIDCDiscoveryResponse.kt
@@ -65,9 +65,37 @@ data class OIDCDiscoveryResponse(
     companion object {
         /**
          * baseUrlからOIDC Discoveryレスポンスを生成
+         *
+         * @param baseUrl サーバーのベースURL
+         * @param emailEnabled emailスコープが有効かどうか（emailFormatが設定されている場合true）
          */
-        fun fromBaseUrl(baseUrl: String): OIDCDiscoveryResponse {
+        fun fromBaseUrl(baseUrl: String, emailEnabled: Boolean = false): OIDCDiscoveryResponse {
             val normalizedUrl = baseUrl.trimEnd('/')
+
+            // emailが有効な場合はemailスコープとクレームを追加
+            val scopes = buildList {
+                add("openid")
+                add("profile")
+                if (emailEnabled) add("email")
+            }
+
+            val claims = buildList {
+                add("sub")
+                add("name")
+                add("nickname")
+                add("picture")
+                if (emailEnabled) {
+                    add("email")
+                    add("email_verified")
+                }
+                add("iss")
+                add("aud")
+                add("exp")
+                add("iat")
+                add("auth_time")
+                add("nonce")
+                add("at_hash")
+            }
 
             return OIDCDiscoveryResponse(
                 issuer = normalizedUrl,
@@ -78,24 +106,12 @@ data class OIDCDiscoveryResponse(
                 responseTypesSupported = listOf("code"),
                 subjectTypesSupported = listOf("public"),
                 idTokenSigningAlgValuesSupported = listOf("RS256"),
-                scopesSupported = listOf("openid", "profile"),
+                scopesSupported = scopes,
                 tokenEndpointAuthMethodsSupported = listOf(
                     "client_secret_post",
                     "none"
                 ),
-                claimsSupported = listOf(
-                    "sub",
-                    "name",
-                    "nickname",
-                    "picture",
-                    "iss",
-                    "aud",
-                    "exp",
-                    "iat",
-                    "auth_time",
-                    "nonce",
-                    "at_hash"
-                ),
+                claimsSupported = claims,
                 grantTypesSupported = listOf(
                     "authorization_code",
                     "refresh_token"

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/components/auth/UserInfoResponse.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/components/auth/UserInfoResponse.kt
@@ -1,5 +1,6 @@
 package party.morino.mineauth.core.web.components.auth
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
@@ -9,11 +10,14 @@ import kotlinx.serialization.Serializable
  * スコープに応じて返却されるクレームが決定される：
  * - openid: sub（必須）
  * - profile: name, nickname, picture
+ * - email: email, email_verified
  *
  * @property sub Subject Identifier - ユーザーの一意識別子（UUID形式）
  * @property name ユーザーの表示名（profileスコープが必要）
  * @property nickname ユーザーのニックネーム（profileスコープが必要）
  * @property picture ユーザーのプロフィール画像URL（profileスコープが必要）
+ * @property email ユーザーのメールアドレス（emailスコープが必要）
+ * @property emailVerified メールアドレスの検証状態（常にfalse）
  */
 @Serializable
 data class UserInfoResponse(
@@ -27,7 +31,14 @@ data class UserInfoResponse(
     val nickname: String? = null,
 
     // profile スコープ: プロフィール画像URL
-    val picture: String? = null
+    val picture: String? = null,
+
+    // email スコープ: メールアドレス
+    val email: String? = null,
+
+    // email スコープ: メールアドレス検証状態（常にfalse）
+    @SerialName("email_verified")
+    val emailVerified: Boolean? = null
 ) {
     companion object {
         // Crafthead API - Minecraftスキンからアバター画像を取得
@@ -39,21 +50,42 @@ data class UserInfoResponse(
          * @param sub Subject Identifier（UUID文字列）
          * @param username ユーザー名
          * @param scopes スコープのリスト
+         * @param email 生成されたメールアドレス（emailFormatが設定されている場合）
          * @return スコープに応じたUserInfoResponse
          */
         fun fromScopes(
             sub: String,
             username: String,
-            scopes: List<String>
+            scopes: List<String>,
+            email: String? = null
         ): UserInfoResponse {
             // profileスコープが含まれる場合のみname, nickname, pictureを返す
             val hasProfileScope = scopes.contains("profile")
+            // emailスコープが含まれ、かつemailが提供されている場合のみemailを返す
+            val hasEmailScope = scopes.contains("email") && email != null
+
             return UserInfoResponse(
                 sub = sub,
                 name = if (hasProfileScope) username else null,
                 nickname = if (hasProfileScope) username else null,
-                picture = if (hasProfileScope) "$AVATAR_BASE_URL$sub" else null
+                picture = if (hasProfileScope) "$AVATAR_BASE_URL$sub" else null,
+                email = if (hasEmailScope) email else null,
+                emailVerified = if (hasEmailScope) false else null
             )
+        }
+
+        /**
+         * emailFormatからメールアドレスを生成する
+         *
+         * @param emailFormat メールフォーマット（例: "<uuid>-<username>@example.com"）
+         * @param uuid プレイヤーのUUID
+         * @param username プレイヤー名
+         * @return 生成されたメールアドレス
+         */
+        fun generateEmail(emailFormat: String, uuid: String, username: String): String {
+            return emailFormat
+                .replace("<uuid>", uuid)
+                .replace("<username>", username)
         }
     }
 }

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/WellKnownRouter.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/WellKnownRouter.kt
@@ -21,7 +21,12 @@ object WellKnownRouter : KoinComponent {
             // OIDC Discovery Endpoint
             // OpenID Connect Discovery 1.0 準拠
             get("openid-configuration") {
-                val response = OIDCDiscoveryResponse.fromBaseUrl(config.server.baseUrl)
+                // emailFormatが設定されている場合、emailスコープを有効化
+                val emailEnabled = config.server.emailFormat != null
+                val response = OIDCDiscoveryResponse.fromBaseUrl(
+                    baseUrl = config.server.baseUrl,
+                    emailEnabled = emailEnabled
+                )
                 call.respond(response)
             }
 

--- a/core/src/test/kotlin/party/morino/mineauth/core/web/router/auth/oauth/UserInfoResponseTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/web/router/auth/oauth/UserInfoResponseTest.kt
@@ -80,6 +80,102 @@ class UserInfoResponseTest {
             assertNull(response.nickname)
             assertNull(response.picture)
         }
+
+        @Test
+        @DisplayName("Returns email claims with email scope and email provided")
+        fun returnsEmailClaimsWithEmailScope() {
+            // emailスコープが含まれ、emailが提供されている場合、email, email_verifiedも返される
+            val response = UserInfoResponse.fromScopes(
+                sub = "550e8400-e29b-41d4-a716-446655440000",
+                username = "Steve",
+                scopes = listOf("openid", "email"),
+                email = "550e8400-e29b-41d4-a716-446655440000-Steve@example.com"
+            )
+
+            assertEquals("550e8400-e29b-41d4-a716-446655440000", response.sub)
+            assertEquals("550e8400-e29b-41d4-a716-446655440000-Steve@example.com", response.email)
+            assertEquals(false, response.emailVerified)
+            assertNull(response.name)
+        }
+
+        @Test
+        @DisplayName("Returns no email claims when email scope but no email provided")
+        fun returnsNoEmailWhenNoEmailProvided() {
+            // emailスコープが含まれるが、emailが提供されていない場合、emailクレームは返されない
+            val response = UserInfoResponse.fromScopes(
+                sub = "550e8400-e29b-41d4-a716-446655440000",
+                username = "Steve",
+                scopes = listOf("openid", "email"),
+                email = null
+            )
+
+            assertEquals("550e8400-e29b-41d4-a716-446655440000", response.sub)
+            assertNull(response.email)
+            assertNull(response.emailVerified)
+        }
+
+        @Test
+        @DisplayName("Returns all claims with profile and email scopes")
+        fun returnsAllClaimsWithProfileAndEmailScopes() {
+            // profile + emailスコープの場合、全てのクレームが返される
+            val response = UserInfoResponse.fromScopes(
+                sub = "550e8400-e29b-41d4-a716-446655440000",
+                username = "Steve",
+                scopes = listOf("openid", "profile", "email"),
+                email = "steve@example.com"
+            )
+
+            assertEquals("550e8400-e29b-41d4-a716-446655440000", response.sub)
+            assertEquals("Steve", response.name)
+            assertEquals("Steve", response.nickname)
+            assertEquals("https://crafthead.net/avatar/550e8400-e29b-41d4-a716-446655440000", response.picture)
+            assertEquals("steve@example.com", response.email)
+            assertEquals(false, response.emailVerified)
+        }
+    }
+
+    @Nested
+    @DisplayName("generateEmail")
+    inner class GenerateEmailTest {
+
+        @Test
+        @DisplayName("Generates email with uuid and username placeholders")
+        fun generatesEmailWithPlaceholders() {
+            // <uuid>と<username>のプレースホルダーを置換
+            val email = UserInfoResponse.generateEmail(
+                emailFormat = "<uuid>-<username>@example.com",
+                uuid = "550e8400-e29b-41d4-a716-446655440000",
+                username = "Steve"
+            )
+
+            assertEquals("550e8400-e29b-41d4-a716-446655440000-Steve@example.com", email)
+        }
+
+        @Test
+        @DisplayName("Generates email with only uuid placeholder")
+        fun generatesEmailWithOnlyUuidPlaceholder() {
+            // <uuid>のみのプレースホルダー
+            val email = UserInfoResponse.generateEmail(
+                emailFormat = "<uuid>@minecraft.example.com",
+                uuid = "550e8400-e29b-41d4-a716-446655440000",
+                username = "Steve"
+            )
+
+            assertEquals("550e8400-e29b-41d4-a716-446655440000@minecraft.example.com", email)
+        }
+
+        @Test
+        @DisplayName("Generates email with only username placeholder")
+        fun generatesEmailWithOnlyUsernamePlaceholder() {
+            // <username>のみのプレースホルダー
+            val email = UserInfoResponse.generateEmail(
+                emailFormat = "<username>@minecraft.example.com",
+                uuid = "550e8400-e29b-41d4-a716-446655440000",
+                username = "Steve"
+            )
+
+            assertEquals("Steve@minecraft.example.com", email)
+        }
     }
 
     @Nested

--- a/docs/content/docs/administrator/config/server.mdx
+++ b/docs/content/docs/administrator/config/server.mdx
@@ -16,7 +16,8 @@ description: HTTP server, SSL, JWT, and OAuth configuration
       "keyAlias": "MineAuth",
       "keyStorePassword": "password",
       "privateKeyPassword": "password"
-    }
+    },
+    "emailFormat": "<uuid>-<username>@example.com"  // Optional
   },
   "jwt": {
     "issuer": "https://api.example.com/",
@@ -38,6 +39,22 @@ description: HTTP server, SSL, JWT, and OAuth configuration
 | `baseUrl` | string | Yes | Base URL for endpoints published in OIDC Discovery. Set to proxy URL if using a reverse proxy |
 | `port` | number | Yes | HTTP server port number |
 | `ssl` | object | No | SSL configuration (optional) |
+| `emailFormat` | string | No | Email address format for OIDC email scope. Supports `<uuid>` and `<username>` placeholders |
+
+### Email Format Configuration
+
+When `emailFormat` is set, the OIDC UserInfo endpoint will return `email` and `email_verified` claims when the `email` scope is requested.
+
+**Placeholders:**
+- `<uuid>` - Player's UUID
+- `<username>` - Player's username
+
+**Example formats:**
+- `<uuid>-<username>@example.com` → `550e8400-e29b-41d4-a716-446655440000-Steve@example.com`
+- `<username>@minecraft.example.com` → `Steve@minecraft.example.com`
+- `<uuid>@players.example.com` → `550e8400-e29b-41d4-a716-446655440000@players.example.com`
+
+Note: `email_verified` is always returned as `false` since these are generated addresses, not verified real email addresses.
 
 ### SSL Configuration
 

--- a/docs/content/docs/developer/oauth/userinfo.mdx
+++ b/docs/content/docs/developer/oauth/userinfo.mdx
@@ -29,6 +29,9 @@ The returned claims depend on the access token's scope.
 |-------|--------|
 | `openid` | `sub` |
 | `profile` | `name`, `nickname`, `picture` |
+| `email` | `email`, `email_verified` |
+
+Note: The `email` scope is only available when `emailFormat` is configured in the server settings.
 
 ### Response Examples
 
@@ -51,6 +54,19 @@ The returned claims depend on the access token's scope.
 }
 ```
 
+#### openid + profile + email scope
+
+```json
+{
+  "sub": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "Steve",
+  "nickname": "Steve",
+  "picture": "https://crafthead.net/avatar/550e8400-e29b-41d4-a716-446655440000",
+  "email": "550e8400-e29b-41d4-a716-446655440000-Steve@example.com",
+  "email_verified": false
+}
+```
+
 ## Claim Descriptions
 
 | Claim | Type | Description |
@@ -59,6 +75,8 @@ The returned claims depend on the access token's scope.
 | `name` | String | Player display name |
 | `nickname` | String | Player nickname |
 | `picture` | String | Player avatar image URL (Crafthead API) |
+| `email` | String | Generated email address based on `emailFormat` configuration |
+| `email_verified` | Boolean | Always `false` (generated addresses are not verified) |
 
 ## References
 


### PR DESCRIPTION
## Summary
- Add optional `emailFormat` configuration option to server settings
- Support `<uuid>` and `<username>` placeholders in email format
- Return `email` and `email_verified` claims when `email` scope is requested
- Update OIDC Discovery to include email scope when configured

## Configuration Example
```json
{
  "server": {
    "baseUrl": "https://api.example.com",
    "port": 8080,
    "emailFormat": "<uuid>-<username>@example.com"
  }
}
```

## Response Example
When `email` scope is requested with `emailFormat` configured:
```json
{
  "sub": "550e8400-e29b-41d4-a716-446655440000",
  "email": "550e8400-e29b-41d4-a716-446655440000-Steve@example.com",
  "email_verified": false
}
```

## Files Changed
- `MineAuthConfig.kt` - Add emailFormat to ServerConfig
- `UserInfoResponse.kt` - Add email, email_verified fields and generateEmail method
- `OIDCDiscoveryResponse.kt` - Add emailEnabled parameter to fromBaseUrl
- `WellKnownRouter.kt` - Pass emailEnabled to OIDCDiscoveryResponse
- `ProfileRouter.kt` - Add email scope handling
- `UserInfoResponseTest.kt` - Add tests for email claims

## Test plan
- [x] Build passes
- [x] All tests pass
- [ ] Manual testing with emailFormat configured
- [ ] Verify OIDC Discovery shows email scope
- [ ] Verify userinfo returns email claims

Closes #219