### PR TITLE
🐛 Fix JWT client validation to use database

### DIFF
--- a/core/src/main/kotlin/party/morino/mineauth/core/web/WebServer.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/WebServer.kt
@@ -25,6 +25,7 @@ import party.morino.mineauth.core.file.data.JWTConfigData
 import party.morino.mineauth.core.file.data.WebServerConfigData
 import party.morino.mineauth.core.utils.PlayerUtils.toOfflinePlayer
 import party.morino.mineauth.core.utils.PlayerUtils.toUUID
+import party.morino.mineauth.core.repository.OAuthClientRepository
 import party.morino.mineauth.core.web.router.auth.AuthRouter.authRouter
 import party.morino.mineauth.core.web.router.common.CommonRouter.commonRouter
 import party.morino.mineauth.core.web.router.plugin.PluginRouter.pluginRouter
@@ -87,9 +88,10 @@ internal fun Application.module() {
             }
 
             validate { credential ->
+                // JWTからクライアントIDを取得してDBで検証
                 val clientId = credential.payload.getClaim("client_id").asString()
-                val folder = plugin.dataFolder.resolve("clients").resolve(clientId).resolve("data.json")
-                if (folder.exists()) {
+                val clientResult = OAuthClientRepository.findById(clientId)
+                if (clientResult.isRight()) {
                     JWTPrincipal(credential.payload)
                 } else {
                     null


### PR DESCRIPTION
## Summary
Fix "Token is not valid or has expired" error that occurred after OAuth client data was migrated to database.

## Problem
After #214 migrated OAuth client data from file-based storage (`clients/` directory) to database, the JWT validation function in `WebServer.kt` was still checking for the existence of `clients/{clientId}/data.json` file. Since this file no longer exists, all token validation failed.

## Solution
Update the JWT `validate` function to use `OAuthClientRepository.findById(clientId)` to verify client existence in the database instead of file-based lookup.

## Files Changed
- `core/src/main/kotlin/party/morino/mineauth/core/web/WebServer.kt`

## Test plan
- [x] Build passes
- [ ] Token validation works after migration to database