### PR TITLE
♻️ Fix addon Koin and OpenAPI dynamic URL resolution

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -52,8 +52,18 @@ jobs:
       - name: Rename artifacts
         run: |
           mv ./core/build/libs/core-*-all.jar ./core/build/libs/MineAuth-core_${{ env.PLUGIN_VERSION }}.jar
-          mv ./addons/quickshop-hikari/build/libs/quickshop-hikari-*-all.jar ./addons/quickshop-hikari/build/libs/MineAuth-addon-quickshop-hikari-${{ env.PLUGIN_VERSION }}.jar
-          mv ./addons/vault/build/libs/vault-*-all.jar ./addons/vault/build/libs/MineAuth-addon-vault-${{ env.PLUGIN_VERSION }}.jar
+
+          # 動的にすべてのaddonを検出してリネーム
+          for addon_dir in ./addons/*/; do
+            addon_name=$(basename "$addon_dir")
+            jar_file=$(find "${addon_dir}build/libs/" -name "${addon_name}-*-all.jar" 2>/dev/null | head -1)
+            if [ -n "$jar_file" ]; then
+              mv "$jar_file" "${addon_dir}build/libs/MineAuth-addon-${addon_name}-${{ env.PLUGIN_VERSION }}.jar"
+              echo "Renamed addon: ${addon_name}"
+            else
+              echo "No JAR found for addon: ${addon_name}"
+            fi
+          done
 
       # GitHub Attestations で署名（Core）
       - name: Attest Core JAR artifact

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,6 +35,11 @@ tasks:
       - sleep 5 && echo "starting server..."
       - ./gradlew clean :addons:quickshop-hikari:runServer
     silent: true
+  clear:
+    cmds:
+      - rm ./core/run/**/session.lock
+      - rm ./addons/**/run/**/session.lock
+    silent: true
   commit:
     cmds:
       - task format

--- a/addons/odailyquests/build.gradle.kts
+++ b/addons/odailyquests/build.gradle.kts
@@ -21,8 +21,6 @@ dependencies {
 
     implementation(libs.bundles.commands)
 
-    implementation(libs.koin.core)
-
     // Paperのlibraries機能またはMineAuthコアから提供されるライブラリ（compileOnly）
     compileOnly(libs.kotlinx.serialization.json)
     compileOnly(libs.bundles.coroutines)

--- a/addons/odailyquests/src/main/kotlin/party/morino/mineauth/addons/odailyquests/ODailyQuestsAddon.kt
+++ b/addons/odailyquests/src/main/kotlin/party/morino/mineauth/addons/odailyquests/ODailyQuestsAddon.kt
@@ -1,7 +1,6 @@
 package party.morino.mineauth.addons.odailyquests
 
 import org.bukkit.plugin.java.JavaPlugin
-import org.koin.core.context.GlobalContext
 import party.morino.mineauth.addons.odailyquests.routes.QuestsHandler
 import party.morino.mineauth.api.MineAuthAPI
 
@@ -26,13 +25,6 @@ class ODailyQuestsAddon : JavaPlugin() {
         }
         mineAuthAPI = api
 
-        // Koinコンテキストの確認
-        if (!verifyKoin()) {
-            logger.severe("Koin is not initialized. MineAuth must be loaded before this addon.")
-            server.pluginManager.disablePlugin(this)
-            return
-        }
-
         // ODailyQuestsプラグインの存在確認
         if (!verifyODailyQuests()) {
             logger.severe("ODailyQuests plugin not found")
@@ -48,17 +40,6 @@ class ODailyQuestsAddon : JavaPlugin() {
 
     override fun onDisable() {
         logger.info("ODailyQuests Addon disabled")
-    }
-
-    /**
-     * Koinコンテキストの検証
-     * MineAuthが起動したKoinコンテキストが存在するか確認する
-     *
-     * @return Koinが初期化済みの場合はtrue
-     */
-    private fun verifyKoin(): Boolean {
-        val koinApp = GlobalContext.getOrNull()
-        return koinApp != null
     }
 
     /**

--- a/addons/odailyquests/src/main/kotlin/party/morino/mineauth/addons/odailyquests/routes/QuestsHandler.kt
+++ b/addons/odailyquests/src/main/kotlin/party/morino/mineauth/addons/odailyquests/routes/QuestsHandler.kt
@@ -2,7 +2,6 @@ package party.morino.mineauth.addons.odailyquests.routes
 
 import com.ordwen.odailyquests.api.ODailyQuestsAPI
 import org.bukkit.OfflinePlayer
-import org.koin.core.component.KoinComponent
 import party.morino.mineauth.addons.odailyquests.data.PlayerQuestsResponse
 import party.morino.mineauth.addons.odailyquests.data.QuestProgressData
 import party.morino.mineauth.api.annotations.AuthedAccessUser
@@ -14,7 +13,7 @@ import party.morino.mineauth.api.http.HttpStatus
  * O'DailyQuestsのクエスト情報を提供するハンドラー
  * /api/v1/plugins/{plugin-name}/ 配下にエンドポイントを提供する
  */
-class QuestsHandler : KoinComponent {
+class QuestsHandler {
 
     /**
      * 自分のクエスト情報を取得する

--- a/addons/quickshop-hikari/src/main/kotlin/party/morino/mineauth/addons/quickshop/QuickShopHikariAddon.kt
+++ b/addons/quickshop-hikari/src/main/kotlin/party/morino/mineauth/addons/quickshop/QuickShopHikariAddon.kt
@@ -2,9 +2,8 @@ package party.morino.mineauth.addons.quickshop
 
 import com.ghostchu.quickshop.api.QuickShopAPI
 import org.bukkit.plugin.java.JavaPlugin
-import org.koin.core.context.GlobalContext
-import org.koin.core.context.loadKoinModules
 import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
 import org.koin.dsl.module
 import party.morino.mineauth.addons.quickshop.routes.ShopHandler
 import party.morino.mineauth.api.MineAuthAPI
@@ -20,11 +19,24 @@ class QuickShopHikariAddon : JavaPlugin() {
     override fun onEnable() {
         logger.info("QuickShop Hikari Addon enabling...")
 
-        // MineAuthAPIの取得
-        mineAuthAPI = server.pluginManager.getPlugin("MineAuth") as MineAuthAPI?
-            ?: throw IllegalStateException("MineAuth plugin not found")
+        // MineAuthAPIの取得（safe castを使用してgraceful disableに対応）
+        val mineAuthPlugin = server.pluginManager.getPlugin("MineAuth")
+        val api = mineAuthPlugin as? MineAuthAPI
+        if (api == null) {
+            logger.severe("MineAuth plugin not found or is not a valid MineAuthAPI instance")
+            server.pluginManager.disablePlugin(this)
+            return
+        }
+        mineAuthAPI = api
 
-        // Koinモジュールの設定
+        // QuickShop-Hikariプラグインの存在確認
+        if (!verifyQuickShop()) {
+            logger.severe("QuickShop-Hikari plugin not found")
+            server.pluginManager.disablePlugin(this)
+            return
+        }
+
+        // Koinの初期化
         setupKoin()
 
         // MineAuthにハンドラーを登録
@@ -34,35 +46,43 @@ class QuickShopHikariAddon : JavaPlugin() {
     }
 
     override fun onDisable() {
+        stopKoin()
         logger.info("QuickShop Hikari Addon disabled")
     }
 
     /**
-     * Koinの設定
-     * MineAuthが起動したKoinコンテキストにQuickShopAPIモジュールを追加する
+     * QuickShop-Hikariプラグインの検証
+     *
+     * @return QuickShop-Hikariがロードされている場合はtrue
+     */
+    private fun verifyQuickShop(): Boolean {
+        val qsPlugin = server.pluginManager.getPlugin("QuickShop-Hikari")
+        if (qsPlugin == null) {
+            logger.warning("QuickShop-Hikari plugin not found")
+            return false
+        }
+        logger.info("QuickShop-Hikari plugin found: ${qsPlugin.pluginMeta.version}")
+        return true
+    }
+
+    /**
+     * Koinの初期化
+     * アドオン独自のKoinコンテキストを起動する
      */
     private fun setupKoin() {
-        val quickShopModule = module {
-            // QuickShopAPIのシングルトン登録
-            single<QuickShopAPI> { QuickShopAPI.getInstance() }
-        }
-
-        // MineAuth側のKoinが起動済みならモジュールを追加する
-        val koinApp = GlobalContext.getOrNull()
-        if (koinApp != null) {
-            loadKoinModules(quickShopModule)
-            return
-        }
-
-        // Koin未起動の場合はアドオン側で起動する
         startKoin {
-            modules(quickShopModule)
+            modules(
+                module {
+                    // QuickShopAPIをシングルトンとして登録
+                    single<QuickShopAPI> { QuickShopAPI.getInstance() }
+                }
+            )
         }
     }
 
     /**
      * MineAuthにハンドラーを登録する
-     * 登録されたハンドラーは /api/v1/plugins/quickshop-hikari-addon/ 配下で利用可能
+     * 登録されたハンドラーは /api/v1/plugins/quickshophikari/ 配下で利用可能
      */
     private fun setupMineAuth() {
         mineAuthAPI.createHandler(this)

--- a/core/src/main/kotlin/party/morino/mineauth/core/openapi/OpenApiRouter.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/openapi/OpenApiRouter.kt
@@ -1,6 +1,7 @@
 package party.morino.mineauth.core.openapi
 
 import io.ktor.http.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import org.koin.java.KoinJavaComponent.get
@@ -27,18 +28,33 @@ object OpenApiRouter {
 
         // Scalar UI エンドポイント
         get("/scalar") {
+            // リクエストパスからOpenAPIのURLを動的に計算
+            // /scalar -> /openapi, /api/scalar -> /api/openapi
+            val requestPath = call.request.path()
+            val openApiUrl = requestPath.replaceLast("/scalar", "/openapi")
+
             call.respondText(
                 contentType = ContentType.Text.Html,
-                text = generateScalarHtml()
+                text = generateScalarHtml(openApiUrl)
             )
         }
     }
 
     /**
+     * 文字列の最後に出現するパターンを置換する
+     */
+    private fun String.replaceLast(oldValue: String, newValue: String): String {
+        val index = this.lastIndexOf(oldValue)
+        return if (index < 0) this else this.substring(0, index) + newValue + this.substring(index + oldValue.length)
+    }
+
+    /**
      * Scalar UI用のHTMLを生成する
      * CDN経由でScalar API Referenceを読み込む
+     *
+     * @param openApiUrl OpenAPI specのURL（動的に計算される）
      */
-    private fun generateScalarHtml(): String {
+    private fun generateScalarHtml(openApiUrl: String): String {
         return """
             <!DOCTYPE html>
             <html>
@@ -56,7 +72,7 @@ object OpenApiRouter {
             <body>
                 <script
                     id="api-reference"
-                    data-url="/openapi"
+                    data-url="$openApiUrl"
                     data-configuration='{"theme": "purple"}'
                 ></script>
                 <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>


### PR DESCRIPTION
## Summary
Multiple fixes for addon initialization and OpenAPI documentation.

## Changes

### Koin Initialization
- Each addon now starts its own Koin context instead of trying to access MineAuth's
- Remove unnecessary Koin dependency from ODailyQuests addon (no injection needed)
- QuickShop and Vault addons properly initialize and cleanup their own Koin contexts

**Why**: Each plugin JAR has its own classloader, so `GlobalContext` is not shared between MineAuth and addons.

### OpenAPI Dynamic URL Resolution
- Scalar UI now dynamically resolves OpenAPI spec URL based on request path
  - `/scalar` → `/openapi`, `/api/scalar` → `/api/openapi`
- OAuth2 URLs are generated from `config.server.baseUrl` instead of hardcoded paths
- Added `servers` section to OpenAPI document

**Why**: If a reverse proxy changes the base path, hardcoded URLs would break.

### CI/CD
- `upload.yml` now dynamically detects all addons (same as `preview.yml`)
- Fixes ODailyQuests addon missing from releases

## Test plan
- [ ] Build succeeds
- [ ] Addons load without Koin errors
- [ ] Scalar UI loads OpenAPI spec correctly
- [ ] Release workflow includes all addons