### PR TITLE
Fix value class reflection error and improve command UX

### DIFF
--- a/core/src/main/kotlin/party/morino/mineauth/core/commands/RegisterCommand.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/commands/RegisterCommand.kt
@@ -27,7 +27,7 @@ class RegisterCommand {
             UserAuthData.selectAll().where { UserAuthData.uuid eq sender.uniqueId.toString() }.count()
         } > 0
         if (exist) {
-            sender.sendMessage("You are already registered if you want to change your password use /moripaapi change")
+            sender.sendRichMessage("You are already registered if you want to change your password use <click:suggest_command:'/ma change'><yellow>/ma change</yellow></click>")
             return
         }
         val password = RandomStringUtils.randomAlphanumeric(20)
@@ -55,7 +55,7 @@ class RegisterCommand {
             UserAuthData.selectAll().where { UserAuthData.uuid eq sender.uniqueId.toString() }.count()
         } > 0
         if (!exist) {
-            sender.sendMessage("You are not already registered if you want to register use /moripaapi register")
+            sender.sendRichMessage("You are not already registered if you want to register use <click:suggest_command:'/ma register'><yellow>/ma register</yellow></click>")
             return
         }
         val password = RandomStringUtils.randomAlphanumeric(20)

--- a/core/src/main/kotlin/party/morino/mineauth/core/dialog/OAuthClientCreateHandler.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/dialog/OAuthClientCreateHandler.kt
@@ -122,7 +122,7 @@ object OAuthClientCreateHandler : KoinComponent {
     private fun handleError(player: Player, error: OAuthClientError) {
         val message = when (error) {
             is OAuthClientError.IssuerAccountNotFound ->
-                "アカウントが見つかりません。先に /mineauth register を実行してください"
+                "アカウントが見つかりません。先に <click:suggest_command:'/ma register'>/ma register</click> を実行してください"
             is OAuthClientError.DatabaseError ->
                 "データベースエラーが発生しました: ${error.message}"
             else -> "クライアントの作成に失敗しました"

--- a/core/src/main/kotlin/party/morino/mineauth/core/dialog/ServiceAccountCreateHandler.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/dialog/ServiceAccountCreateHandler.kt
@@ -91,7 +91,7 @@ object ServiceAccountCreateHandler : KoinComponent {
         player.sendRichMessage("<gray>サービス名:</gray> <white>$serviceName</white>")
         player.sendRichMessage("")
         player.sendRichMessage(
-            "<yellow>トークンを発行するには <white>/mineauth service token $serviceName</white> を実行してください</yellow>"
+            "<yellow>トークンを発行するには <click:suggest_command:'/ma service token $serviceName'><white>/ma service token $serviceName</white></click> を実行してください</yellow>"
         )
     }
 }

--- a/core/src/main/kotlin/party/morino/mineauth/core/model/ClientId.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/model/ClientId.kt
@@ -1,8 +1,8 @@
 package party.morino.mineauth.core.model
 
 /**
- * OAuthクライアントIDを表すValue Class
+ * OAuthクライアントIDを表すデータクラス
  * 型安全性を確保し、コマンドパーサーでの使用を可能にする
+ * Note: value classはcloud-kotlin-coroutinesのsuspend関数でリフレクションエラーを起こすためdata classを使用
  */
-@JvmInline
-value class ClientId(val value: String)
+data class ClientId(val value: String)

--- a/core/src/main/kotlin/party/morino/mineauth/core/model/ServiceName.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/model/ServiceName.kt
@@ -1,8 +1,8 @@
 package party.morino.mineauth.core.model
 
 /**
- * サービスアカウント名を表すValue Class
+ * サービスアカウント名を表すデータクラス
  * 型安全性を確保し、コマンドパーサーでの使用を可能にする
+ * Note: value classはcloud-kotlin-coroutinesのsuspend関数でリフレクションエラーを起こすためdata classを使用
  */
-@JvmInline
-value class ServiceName(val value: String)
+data class ServiceName(val value: String)


### PR DESCRIPTION
## Summary
- `@JvmInline value class` (`ServiceName`, `ClientId`) を `data class` に変更し、cloud-kotlin-coroutines の suspend コマンドハンドラでの `IllegalArgumentException: object is not an instance of declaring class` を修正
- プレイヤーメッセージ内のコマンド参照を `/ma` に統一し、`SUGGEST_COMMAND` クリックイベントを追加

## Test plan
- [ ] `/ma service token <name>` が正常に動作すること
- [ ] `/ma client delete <clientId>` が正常に動作すること
- [ ] `/ma service info <name>`, `/ma client info <id>`, `/ma client regenerate-secret <id>` も正常に動作すること
- [ ] コマンド参照のクリックでチャット欄にコマンドがサジェストされること
- [ ] タブ補完が引き続き動作すること