### PR TITLE
📈 Enrich OpenTelemetry traces, metrics, and Minecraft server gauges

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -47,6 +47,7 @@ jobs:
       test_passed: ${{ steps.publish-test-results.outputs.passed }}
       test_skipped: ${{ steps.publish-test-results.outputs.skipped }}
       test_failed: ${{ steps.publish-test-results.outputs.failed }}
+      attestation_url: ${{ steps.attest.outputs.attestation-url }}
     env:
       COMMIT_SHORT_SHA: ${{ needs.setup.outputs.commit_sha }}
     steps:
@@ -77,6 +78,27 @@ jobs:
         continue-on-error: true
         run: ./gradlew build -x test
 
+      - name: Install Allure CLI
+        if: success() || failure()
+        run: |
+          curl -sL https://github.com/allure-framework/allure2/releases/download/2.32.2/allure-2.32.2.tgz | tar -xz
+          echo "$PWD/allure-2.32.2/bin" >> $GITHUB_PATH
+
+      - name: Aggregate Allure results
+        if: success() || failure()
+        run: |
+          mkdir -p ./build/allure-results-aggregated
+          # 各モジュール (core / addons) の allure-results を1箇所へ集約する。
+          # 新しいモジュールにテストを追加してもここを編集せずレポートへ自動的に含まれる。
+          find . -type d -path '*/build/allure-results' -not -path '*/allure-results-aggregated/*' | while read -r dir; do
+            cp -a "$dir/." ./build/allure-results-aggregated/ 2>/dev/null || true
+          done
+
+      - name: Generate Allure report
+        if: success() || failure()
+        continue-on-error: true
+        run: allure generate ./build/allure-results-aggregated -o ./build/allure-report --clean
+
       - name: Publish test results
         id: publish-test-results
         uses: mikepenz/action-junit-report@e08919a3b1fb83a78393dfb775a9c37f17d8eea6 # v6.0.1
@@ -89,6 +111,7 @@ jobs:
           mkdir -p ./gradle-artifacts/jars
           mkdir -p ./gradle-artifacts/junit
           mkdir -p ./gradle-artifacts/detekt
+          mkdir -p ./gradle-artifacts/allure
           mv ./core/build/libs/core-*-all.jar ./gradle-artifacts/jars/${{ env.PROJECT_NAME }}-core-${{ env.COMMIT_SHORT_SHA }}.jar
           # sourcesJARを除外してメインJARのみ移動
           api_jar=$(find ./api/build/libs/ -name "api-*.jar" ! -name "*-sources.jar" | head -1)
@@ -108,9 +131,11 @@ jobs:
 
           cp -r ./core/build/reports/tests/test/* ./gradle-artifacts/junit/ || echo "No JUnit reports found"
           cp -r ./build/reports/detekt/* ./gradle-artifacts/detekt/
+          cp -r ./build/allure-report/* ./gradle-artifacts/allure/ || echo "No Allure reports found"
 
       # GitHub Attestations で署名
       - name: Attest JAR artifacts
+        id: attest
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: './gradle-artifacts/jars/*.jar'
@@ -242,6 +267,7 @@ jobs:
           mkdir -p ./upload
           cp -r ./artifacts/gradle-artifacts/junit ./upload/ || echo "No JUnit reports"
           cp -r ./artifacts/gradle-artifacts/detekt ./upload/ || echo "No Detekt reports"
+          cp -r ./artifacts/gradle-artifacts/allure ./upload/ || echo "No Allure reports"
           mkdir -p ./upload/docs
           mv ./artifacts/docs-artifacts/* ./upload/docs/
 
@@ -256,6 +282,7 @@ jobs:
           # Docs と レポートを並列でアップロード
           aws s3 cp ./upload/junit $S3_BASE/junit $S3_OPTS --recursive &
           aws s3 cp ./upload/detekt $S3_BASE/detekt $S3_OPTS --recursive &
+          aws s3 cp ./upload/allure $S3_BASE/allure $S3_OPTS --recursive &
           aws s3 cp ./upload/docs $S3_BASE/docs $S3_OPTS --recursive &
 
           # 全ての並列アップロードを待機
@@ -289,9 +316,11 @@ jobs:
           RELEASE_URL: "${{ needs.upload-release.outputs.release_url }}"
           RELEASE_DOWNLOAD_BASE: "https://github.com/${{ github.repository }}/releases/download/preview-pr${{ github.event.pull_request.number }}-${{ env.COMMIT_SHORT_SHA }}"
           JUNIT_REPORT_URL: "${{ env.PREVIEW_BASE_URL }}/${{ env.COMMIT_SHORT_SHA }}/junit/index.html"
+          ALLURE_REPORT_URL: "${{ env.PREVIEW_BASE_URL }}/${{ env.COMMIT_SHORT_SHA }}/allure/index.html"
           DETEKT_REPORT_URL: "${{ env.PREVIEW_BASE_URL }}/${{ env.COMMIT_SHORT_SHA }}/detekt/detekt.html"
           DOCS_PREVIEW_URL: "${{ env.PREVIEW_BASE_URL }}/${{ env.COMMIT_SHORT_SHA }}/docs/index.html"
           DOKKA_URL: "${{ env.PREVIEW_BASE_URL }}/${{ env.COMMIT_SHORT_SHA }}/docs/dokka/index.html"
+          ATTESTATION_URL: "${{ needs.build-gradle.outputs.attestation_url }}"
           LIMIT_TIME: ${{ env.LIMIT_TIME }}
         run: |
           # 動的にaddonの行を生成
@@ -317,7 +346,7 @@ jobs:
           | Core | [${{ env.PROJECT_NAME }}-core-${{ env.COMMIT_SHORT_SHA }}.jar]($RELEASE_DOWNLOAD_BASE/${{ env.PROJECT_NAME }}-core-${{ env.COMMIT_SHORT_SHA }}.jar) |
           | API | [${{ env.PROJECT_NAME }}-api-${{ env.COMMIT_SHORT_SHA }}.jar]($RELEASE_DOWNLOAD_BASE/${{ env.PROJECT_NAME }}-api-${{ env.COMMIT_SHORT_SHA }}.jar) |
           ${ADDON_ROWS}
-          > 📜 **Attestation**: \`gh attestation verify <jar-file> --owner morinoparty\`
+          > 📜 **Attestation** (SLSA provenance): [Verify on GitHub]($ATTESTATION_URL) or run \`gh attestation verify <jar-file> --owner morinoparty\`
 
           ### 📖 Documentation & Reports
           Available for 7 days (until $LIMIT_TIME)
@@ -325,6 +354,7 @@ jobs:
           |----------|------|
           | 📖 Documentation | [Preview]($DOCS_PREVIEW_URL) |
           | 📖 Dokka API | [Preview]($DOKKA_URL) |
+          | 🧪 Allure Report | [Report]($ALLURE_REPORT_URL) |
           | 🧪 JUnit Report | [Report]($JUNIT_REPORT_URL) |
           | 🔍 Detekt Report | [Report]($DETEKT_REPORT_URL) |
 

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -74,12 +74,14 @@ jobs:
 
       # GitHub Attestations で署名（Core）
       - name: Attest Core JAR artifact
+        id: attest-core
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: './core/build/libs/MineAuth-core_${{ env.PLUGIN_VERSION }}.jar'
 
       # GitHub Attestations で署名（Addons - 動的に検出）
       - name: Attest Addon JAR artifacts
+        id: attest-addons
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: './addons/*/build/libs/MineAuth-addon-*-${{ env.PLUGIN_VERSION }}.jar'
@@ -115,4 +117,23 @@ jobs:
           gh release upload ${{ github.event.release.tag_name }} \
             ./addons/*/build/libs/MineAuth-addon-*-${{ env.PLUGIN_VERSION }}.jar \
             --clobber
+
+      # リリースノートに SLSA provenance の確認リンクを追記する
+      - name: Append SLSA provenance link to release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+          CORE_ATTESTATION_URL: ${{ steps.attest-core.outputs.attestation-url }}
+          ADDONS_ATTESTATION_URL: ${{ steps.attest-addons.outputs.attestation-url }}
+        run: |
+          gh release view "$TAG" --json body -q .body > notes.md
+          cat << EOF >> notes.md
+
+          ## 🔏 Provenance (SLSA)
+
+          Verify with \`gh attestation verify <jar-file> --owner morinoparty\`, or check the attestations directly:
+          - Core: [View attestation]($CORE_ATTESTATION_URL)
+          - Addons: [View attestation]($ADDONS_ATTESTATION_URL)
+          EOF
+          gh release edit "$TAG" --notes-file notes.md
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,8 @@ allprojects {
         }
         test {
             useJUnitPlatform()
+            // Allure結果の出力先を指定（CIでレポート生成する際に集約する）
+            systemProperty("allure.results.directory", "${project.layout.buildDirectory.get().asFile}/allure-results")
             testLogging {
                 showStandardStreams = true
                 events("passed", "skipped", "failed")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -44,6 +44,8 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.mock.bukkit)
     testImplementation(libs.ktor.server.test.host)
+    // OpenTelemetryのテスト用（InMemorySpanExporter / InMemoryMetricReader）
+    testImplementation(libs.opentelemetry.sdk.testing)
     // compileOnlyのライブラリをテストでも使えるようにする
     testImplementation(libs.paper.api)
     testImplementation(libs.kotlinx.serialization.json)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
     testImplementation(libs.ktor.server.test.host)
     // OpenTelemetryのテスト用（InMemorySpanExporter / InMemoryMetricReader）
     testImplementation(libs.opentelemetry.sdk.testing)
+    // Allureレポート用（JUnit5の実行結果をallure-resultsとして出力する）
+    testImplementation(libs.allure.junit5)
     // compileOnlyのライブラリをテストでも使えるようにする
     testImplementation(libs.paper.api)
     testImplementation(libs.kotlinx.serialization.json)

--- a/core/src/main/kotlin/party/morino/mineauth/core/file/data/MineAuthConfig.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/file/data/MineAuthConfig.kt
@@ -97,7 +97,16 @@ data class ObservabilityConfig(
     val metricsEnabled: Boolean = true,
 
     // ヘルスチェックエンドポイント(/health)を有効にするかどうか
-    val healthEnabled: Boolean = true
+    val healthEnabled: Boolean = true,
+
+    // OTLPでメトリクスをエクスポートするかどうか（enabled=trueの場合のみ有効）
+    val otlpMetricsEnabled: Boolean = true,
+
+    // メトリクスのエクスポート間隔（秒）
+    val metricExportIntervalSeconds: Long = 60,
+
+    // service.namespaceリソース属性（複数サーバー運用時の論理グループ名）
+    val serviceNamespace: String = "minecraft"
 )
 
 /**

--- a/core/src/main/kotlin/party/morino/mineauth/core/plugin/route/RouteExecutor.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/plugin/route/RouteExecutor.kt
@@ -4,12 +4,15 @@ import arrow.core.Either
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
+import io.opentelemetry.api.common.Attributes
 import kotlinx.serialization.json.JsonPrimitive
 import org.koin.core.component.KoinComponent
 import org.slf4j.LoggerFactory
 import party.morino.mineauth.core.plugin.annotation.EndpointMetadata
 import party.morino.mineauth.core.plugin.execution.ExecutionError
 import party.morino.mineauth.core.plugin.execution.MethodExecutionHandlerFactory
+import party.morino.mineauth.core.web.telemetry.TelemetryAttributes
+import party.morino.mineauth.core.web.telemetry.withSpan
 import kotlin.reflect.KParameter
 
 /**
@@ -31,21 +34,29 @@ class RouteExecutor(
      * @param metadata エンドポイントメタデータ
      */
     suspend fun execute(call: ApplicationCall, metadata: EndpointMetadata) {
-        // 認証・認可が必要なら先にチェックする
-        if (!authenticateIfNeeded(call, metadata)) {
-            return
-        }
+        // アドオンルート全体の処理を1つのスパンで計測する（全アドオンルートの単一チョークポイント）
+        val attributes = Attributes.builder()
+            .put(TelemetryAttributes.HANDLER_CLASS, metadata.handlerInstance::class.qualifiedName ?: "unknown")
+            .put(TelemetryAttributes.ENDPOINT_PATH, metadata.path)
+            .put(TelemetryAttributes.ENDPOINT_METHOD, metadata.httpMethod.name)
+            .build()
+        withSpan("mineauth.plugin.handler", attributes = attributes) {
+            // 認証・認可が必要なら先にチェックする
+            if (!authenticateIfNeeded(call, metadata)) {
+                return@withSpan
+            }
 
-        // パラメータ解決に失敗した場合はレスポンス済みで終了
-        val resolvedParams = resolveParameters(call, metadata) ?: return
+            // パラメータ解決に失敗した場合はレスポンス済みで終了
+            val resolvedParams = resolveParameters(call, metadata) ?: return@withSpan
 
-        // ファクトリ経由でハンドラーを取得
-        val handler = executionHandlerFactory.createHandler(metadata)
+            // ファクトリ経由でハンドラーを取得
+            val handler = executionHandlerFactory.createHandler(metadata)
 
-        // ハンドラーを実行して結果を処理
-        when (val result = handler.execute(metadata, resolvedParams)) {
-            is Either.Left -> handleExecutionError(call, result.value, metadata, resolvedParams)
-            is Either.Right -> handleResult(call, result.value)
+            // ハンドラーを実行して結果を処理
+            when (val result = handler.execute(metadata, resolvedParams)) {
+                is Either.Left -> handleExecutionError(call, result.value, metadata, resolvedParams)
+                is Either.Right -> handleResult(call, result.value)
+            }
         }
     }
 

--- a/core/src/main/kotlin/party/morino/mineauth/core/repository/AccountRepository.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/repository/AccountRepository.kt
@@ -12,6 +12,7 @@ import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
 import party.morino.mineauth.core.database.Accounts
+import party.morino.mineauth.core.web.telemetry.withDatabaseSpan
 import java.util.*
 
 /**
@@ -98,21 +99,24 @@ object AccountRepository {
      * @param accountId アカウントID（UUIDv7）
      * @return 成功時はアカウントデータ、失敗時はエラー
      */
-    suspend fun findById(accountId: String): Either<AccountError, AccountData> = newSuspendedTransaction {
-        try {
-            val row = Accounts.selectAll()
-                .where { Accounts.accountId eq accountId }
-                .firstOrNull()
+    suspend fun findById(accountId: String): Either<AccountError, AccountData> =
+        withDatabaseSpan("accounts", "select") {
+            newSuspendedTransaction {
+                try {
+                    val row = Accounts.selectAll()
+                        .where { Accounts.accountId eq accountId }
+                        .firstOrNull()
 
-            if (row == null) {
-                AccountError.NotFound.left()
-            } else {
-                row.toAccountData().right()
+                    if (row == null) {
+                        AccountError.NotFound.left()
+                    } else {
+                        row.toAccountData().right()
+                    }
+                } catch (e: Exception) {
+                    AccountError.DatabaseError(e.message ?: "Unknown error").left()
+                }
             }
-        } catch (e: Exception) {
-            AccountError.DatabaseError(e.message ?: "Unknown error").left()
         }
-    }
 
     /**
      * identifierでアカウントを取得する

--- a/core/src/main/kotlin/party/morino/mineauth/core/repository/OAuthClientRepository.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/repository/OAuthClientRepository.kt
@@ -14,6 +14,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTrans
 import org.jetbrains.exposed.v1.jdbc.update
 import party.morino.mineauth.core.database.OAuthClients
 import party.morino.mineauth.core.utils.Argon2Utils
+import party.morino.mineauth.core.web.telemetry.withDatabaseSpan
 import java.security.SecureRandom
 import java.time.LocalDateTime
 import java.util.*
@@ -153,21 +154,24 @@ object OAuthClientRepository {
      * @param clientId クライアントID
      * @return 成功時はクライアントデータ、失敗時はエラー
      */
-    suspend fun findById(clientId: String): Either<OAuthClientError, OAuthClientData> = newSuspendedTransaction {
-        try {
-            val row = OAuthClients.selectAll()
-                .where { OAuthClients.clientId eq clientId }
-                .firstOrNull()
+    suspend fun findById(clientId: String): Either<OAuthClientError, OAuthClientData> =
+        withDatabaseSpan("oauth_clients", "select") {
+            newSuspendedTransaction {
+                try {
+                    val row = OAuthClients.selectAll()
+                        .where { OAuthClients.clientId eq clientId }
+                        .firstOrNull()
 
-            if (row == null) {
-                OAuthClientError.NotFound.left()
-            } else {
-                row.toOAuthClientData().right()
+                    if (row == null) {
+                        OAuthClientError.NotFound.left()
+                    } else {
+                        row.toOAuthClientData().right()
+                    }
+                } catch (e: Exception) {
+                    OAuthClientError.DatabaseError(e.message ?: "Unknown error").left()
+                }
             }
-        } catch (e: Exception) {
-            OAuthClientError.DatabaseError(e.message ?: "Unknown error").left()
         }
-    }
 
     /**
      * クライアントシークレットを検証する
@@ -179,35 +183,37 @@ object OAuthClientRepository {
     suspend fun verifyClientSecret(
         clientId: String,
         clientSecret: String
-    ): Either<OAuthClientError, OAuthClientData> = newSuspendedTransaction {
-        try {
-            val row = OAuthClients.selectAll()
-                .where { OAuthClients.clientId eq clientId }
-                .firstOrNull()
+    ): Either<OAuthClientError, OAuthClientData> = withDatabaseSpan("oauth_clients", "select") {
+        newSuspendedTransaction {
+            try {
+                val row = OAuthClients.selectAll()
+                    .where { OAuthClients.clientId eq clientId }
+                    .firstOrNull()
 
-            if (row == null) {
-                return@newSuspendedTransaction OAuthClientError.NotFound.left()
+                if (row == null) {
+                    return@newSuspendedTransaction OAuthClientError.NotFound.left()
+                }
+
+                val clientType = ClientType.fromValue(row[OAuthClients.clientType])
+                if (clientType != ClientType.CONFIDENTIAL) {
+                    // Publicクライアントにはシークレット検証は不要
+                    return@newSuspendedTransaction OAuthClientError.InvalidCredentials.left()
+                }
+
+                val storedHash = row[OAuthClients.clientSecretHash]
+                if (storedHash == null) {
+                    return@newSuspendedTransaction OAuthClientError.InvalidCredentials.left()
+                }
+
+                // Argon2idで検証（定数時間比較）
+                if (!Argon2Utils.verifySecret(clientSecret, storedHash)) {
+                    return@newSuspendedTransaction OAuthClientError.InvalidCredentials.left()
+                }
+
+                row.toOAuthClientData().right()
+            } catch (e: Exception) {
+                OAuthClientError.DatabaseError(e.message ?: "Unknown error").left()
             }
-
-            val clientType = ClientType.fromValue(row[OAuthClients.clientType])
-            if (clientType != ClientType.CONFIDENTIAL) {
-                // Publicクライアントにはシークレット検証は不要
-                return@newSuspendedTransaction OAuthClientError.InvalidCredentials.left()
-            }
-
-            val storedHash = row[OAuthClients.clientSecretHash]
-            if (storedHash == null) {
-                return@newSuspendedTransaction OAuthClientError.InvalidCredentials.left()
-            }
-
-            // Argon2idで検証（定数時間比較）
-            if (!Argon2Utils.verifySecret(clientSecret, storedHash)) {
-                return@newSuspendedTransaction OAuthClientError.InvalidCredentials.left()
-            }
-
-            row.toOAuthClientData().right()
-        } catch (e: Exception) {
-            OAuthClientError.DatabaseError(e.message ?: "Unknown error").left()
         }
     }
 

--- a/core/src/main/kotlin/party/morino/mineauth/core/repository/RevokedTokenRepository.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/repository/RevokedTokenRepository.kt
@@ -11,6 +11,7 @@ import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
 import party.morino.mineauth.core.database.RevokedTokens
+import party.morino.mineauth.core.web.telemetry.withDatabaseSpan
 import java.time.LocalDateTime
 
 /**
@@ -60,28 +61,30 @@ object RevokedTokenRepository {
         tokenType: TokenType,
         clientId: String,
         expiresAt: LocalDateTime
-    ): Either<RevokedTokenError, Unit> = newSuspendedTransaction {
-        try {
-            // 既に失効済みかチェック
-            val existing = RevokedTokens.selectAll()
-                .where { RevokedTokens.tokenId eq tokenId }
-                .firstOrNull()
+    ): Either<RevokedTokenError, Unit> = withDatabaseSpan("revoked_tokens", "insert") {
+        newSuspendedTransaction {
+            try {
+                // 既に失効済みかチェック
+                val existing = RevokedTokens.selectAll()
+                    .where { RevokedTokens.tokenId eq tokenId }
+                    .firstOrNull()
 
-            if (existing != null) {
-                // RFC 7009: 既に失効済みでも成功として扱う
-                return@newSuspendedTransaction Unit.right()
+                if (existing != null) {
+                    // RFC 7009: 既に失効済みでも成功として扱う
+                    return@newSuspendedTransaction Unit.right()
+                }
+
+                RevokedTokens.insert {
+                    it[RevokedTokens.tokenId] = tokenId
+                    it[RevokedTokens.tokenType] = tokenType.value
+                    it[RevokedTokens.clientId] = clientId
+                    it[RevokedTokens.expiresAt] = expiresAt
+                }
+
+                Unit.right()
+            } catch (e: Exception) {
+                RevokedTokenError.DatabaseError(e.message ?: "Unknown error").left()
             }
-
-            RevokedTokens.insert {
-                it[RevokedTokens.tokenId] = tokenId
-                it[RevokedTokens.tokenType] = tokenType.value
-                it[RevokedTokens.clientId] = clientId
-                it[RevokedTokens.expiresAt] = expiresAt
-            }
-
-            Unit.right()
-        } catch (e: Exception) {
-            RevokedTokenError.DatabaseError(e.message ?: "Unknown error").left()
         }
     }
 
@@ -91,14 +94,16 @@ object RevokedTokenRepository {
      * @param tokenId トークンのJWT ID（jti claim）
      * @return 失効済みの場合true
      */
-    suspend fun isRevoked(tokenId: String): Boolean = newSuspendedTransaction {
-        try {
-            RevokedTokens.selectAll()
-                .where { RevokedTokens.tokenId eq tokenId }
-                .firstOrNull() != null
-        } catch (e: Exception) {
-            // エラー時は安全側に倒して失効済みとして扱う
-            true
+    suspend fun isRevoked(tokenId: String): Boolean = withDatabaseSpan("revoked_tokens", "select") {
+        newSuspendedTransaction {
+            try {
+                RevokedTokens.selectAll()
+                    .where { RevokedTokens.tokenId eq tokenId }
+                    .firstOrNull() != null
+            } catch (e: Exception) {
+                // エラー時は安全側に倒して失効済みとして扱う
+                true
+            }
         }
     }
 

--- a/core/src/main/kotlin/party/morino/mineauth/core/repository/ServiceAccountTokenRepository.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/repository/ServiceAccountTokenRepository.kt
@@ -12,6 +12,7 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
 import org.jetbrains.exposed.v1.jdbc.update
 import party.morino.mineauth.core.database.ServiceAccountTokens
+import party.morino.mineauth.core.web.telemetry.withDatabaseSpan
 import java.time.LocalDateTime
 
 /**
@@ -219,15 +220,17 @@ object ServiceAccountTokenRepository {
     /**
      * トークンが有効かどうかを確認する（revoked = false）
      */
-    suspend fun isTokenValid(tokenId: String): Boolean = newSuspendedTransaction {
-        try {
-            val row = ServiceAccountTokens.selectAll()
-                .where { ServiceAccountTokens.tokenId eq tokenId }
-                .firstOrNull()
+    suspend fun isTokenValid(tokenId: String): Boolean = withDatabaseSpan("service_account_tokens", "select") {
+        newSuspendedTransaction {
+            try {
+                val row = ServiceAccountTokens.selectAll()
+                    .where { ServiceAccountTokens.tokenId eq tokenId }
+                    .firstOrNull()
 
-            row != null && !row[ServiceAccountTokens.revoked]
-        } catch (e: Exception) {
-            false
+                row != null && !row[ServiceAccountTokens.revoked]
+            } catch (e: Exception) {
+                false
+            }
         }
     }
 
@@ -242,16 +245,18 @@ object ServiceAccountTokenRepository {
      * 最終使用日時を更新する
      */
     suspend fun updateLastUsedAt(tokenId: String): Either<ServiceAccountTokenError, Unit> =
-        newSuspendedTransaction {
-            try {
-                ServiceAccountTokens.update(
-                    where = { ServiceAccountTokens.tokenId eq tokenId }
-                ) {
-                    it[lastUsedAt] = LocalDateTime.now()
+        withDatabaseSpan("service_account_tokens", "update") {
+            newSuspendedTransaction {
+                try {
+                    ServiceAccountTokens.update(
+                        where = { ServiceAccountTokens.tokenId eq tokenId }
+                    ) {
+                        it[lastUsedAt] = LocalDateTime.now()
+                    }
+                    Unit.right()
+                } catch (e: Exception) {
+                    ServiceAccountTokenError.DatabaseError(e.message ?: "Unknown error").left()
                 }
-                Unit.right()
-            } catch (e: Exception) {
-                ServiceAccountTokenError.DatabaseError(e.message ?: "Unknown error").left()
             }
         }
 

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/WebServer.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/WebServer.kt
@@ -15,9 +15,11 @@ import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry
 import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import io.opentelemetry.instrumentation.ktor.v3_0.KtorServerTelemetry
+import io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegistry
 import org.slf4j.event.Level
 import io.ktor.server.velocity.*
 import org.apache.velocity.runtime.RuntimeConstants
@@ -42,7 +44,10 @@ import party.morino.mineauth.core.web.router.auth.AuthRouter.authRouter
 import party.morino.mineauth.core.web.router.common.CommonRouter.commonRouter
 import party.morino.mineauth.core.web.router.plugin.PluginRouter.pluginRouter
 import party.morino.mineauth.core.plugin.PluginRouteRegistry
+import party.morino.mineauth.core.web.telemetry.MinecraftMetrics
+import party.morino.mineauth.core.web.telemetry.TelemetryAttributes
 import party.morino.mineauth.core.web.telemetry.TelemetryProvider
+import party.morino.mineauth.core.web.telemetry.withSpan
 import java.security.KeyStore
 import java.util.concurrent.TimeUnit
 
@@ -99,8 +104,22 @@ internal fun Application.module() {
         }
     }
 
-    // Prometheusメトリクスレジストリ
-    val appMicrometerRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+    // Prometheusメトリクスレジストリ（/metricsエンドポイント用）
+    val prometheusRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+
+    // 複合レジストリ: 1回の登録でPrometheusとOTLPの両方にメトリクスを出す
+    val meterRegistry = CompositeMeterRegistry().apply {
+        add(prometheusRegistry)
+        // OTLPメトリクスが有効な場合はMicrometer→OTelブリッジを追加
+        if (observabilityConfig.enabled && observabilityConfig.otlpMetricsEnabled) {
+            add(OpenTelemetryMeterRegistry.create(openTelemetry))
+        }
+    }
+
+    // reload時にレジストリをクローズしてメーターのリークを防ぐ
+    monitor.subscribe(ApplicationStopped) {
+        meterRegistry.close()
+    }
 
     // HTTPリクエスト/レスポンスのロギング
     install(CallLogging) {
@@ -123,9 +142,16 @@ internal fun Application.module() {
 
     // Micrometerメトリクス
     install(MicrometerMetrics) {
-        registry = appMicrometerRegistry
+        registry = meterRegistry
         // メトリクス収集対象から除外するパス
         distinctNotRegisteredRoutes = false
+    }
+
+    // Minecraftサーバーのメトリクス（プレイヤー数・TPS・MSPTなど）を登録
+    // テスト環境などBukkitサーバーが未初期化の場合はスキップ
+    if (observabilityConfig.metricsEnabled) {
+        runCatching { MinecraftMetrics().bindTo(meterRegistry) }
+            .onFailure { plugin.logger.warning("Could not bind Minecraft metrics: ${it.message}") }
     }
 
     install(ContentNegotiation) {
@@ -151,20 +177,27 @@ internal fun Application.module() {
             }
 
             validate { credential ->
-                // JWTからクライアントIDを取得してDBで検証
-                val clientId = credential.payload.getClaim("client_id").asString()
-                val clientResult = OAuthClientRepository.findById(clientId)
-                if (clientResult.isLeft()) {
-                    return@validate null
-                }
+                // JWT検証の過程をスパンとして記録する（トークン本体は記録しない）
+                withSpan("jwt.validate.user_token") { span ->
+                    // JWTからクライアントIDを取得してDBで検証
+                    val clientId = credential.payload.getClaim("client_id").asString()
+                    clientId?.let { span.setAttribute(TelemetryAttributes.CLIENT_ID, it) }
+                    val clientResult = OAuthClientRepository.findById(clientId)
+                    if (clientResult.isLeft()) {
+                        span.setAttribute(TelemetryAttributes.AUTH_RESULT, "client_not_found")
+                        return@withSpan null
+                    }
 
-                // RFC 7009: トークンが失効済みかチェック
-                val tokenId = credential.payload.id
-                if (tokenId != null && RevokedTokenRepository.isRevokedBlocking(tokenId)) {
-                    return@validate null
-                }
+                    // RFC 7009: トークンが失効済みかチェック
+                    val tokenId = credential.payload.id
+                    if (tokenId != null && RevokedTokenRepository.isRevokedBlocking(tokenId)) {
+                        span.setAttribute(TelemetryAttributes.AUTH_RESULT, "revoked")
+                        return@withSpan null
+                    }
 
-                JWTPrincipal(credential.payload)
+                    span.setAttribute(TelemetryAttributes.AUTH_RESULT, "valid")
+                    JWTPrincipal(credential.payload)
+                }
             }
             challenge { _, _ ->
                 call.respond(HttpStatusCode.Unauthorized, "Token is not valid or has expired")
@@ -179,32 +212,42 @@ internal fun Application.module() {
             }
 
             validate { credential ->
-                // token_typeがservice_tokenであることを確認
-                val tokenType = credential.payload.getClaim("token_type").asString()
-                if (tokenType != "service_token") {
-                    return@validate null
-                }
+                // JWT検証の過程をスパンとして記録する（トークン本体は記録しない）
+                withSpan("jwt.validate.service_token") { span ->
+                    // token_typeがservice_tokenであることを確認
+                    val tokenType = credential.payload.getClaim("token_type").asString()
+                    if (tokenType != "service_token") {
+                        span.setAttribute(TelemetryAttributes.AUTH_RESULT, "wrong_token_type")
+                        return@withSpan null
+                    }
 
-                // accountIdでアカウントの存在確認
-                val accountId = credential.payload.getClaim("account_id").asString()
-                    ?: return@validate null
-                val accountResult = AccountRepository.findById(accountId)
-                if (accountResult.isLeft()) {
-                    return@validate null
-                }
+                    // accountIdでアカウントの存在確認
+                    val accountId = credential.payload.getClaim("account_id").asString()
+                    if (accountId == null) {
+                        span.setAttribute(TelemetryAttributes.AUTH_RESULT, "account_id_missing")
+                        return@withSpan null
+                    }
+                    val accountResult = AccountRepository.findById(accountId)
+                    if (accountResult.isLeft()) {
+                        span.setAttribute(TelemetryAttributes.AUTH_RESULT, "account_not_found")
+                        return@withSpan null
+                    }
 
-                // トークンIDで失効チェック
-                val tokenId = credential.payload.id
-                if (tokenId != null && !ServiceAccountTokenRepository.isTokenValidBlocking(tokenId)) {
-                    return@validate null
-                }
+                    // トークンIDで失効チェック
+                    val tokenId = credential.payload.id
+                    if (tokenId != null && !ServiceAccountTokenRepository.isTokenValidBlocking(tokenId)) {
+                        span.setAttribute(TelemetryAttributes.AUTH_RESULT, "revoked")
+                        return@withSpan null
+                    }
 
-                // 最終使用日時を更新（トークン監査用）
-                if (tokenId != null) {
-                    ServiceAccountTokenRepository.updateLastUsedAtBlocking(tokenId)
-                }
+                    // 最終使用日時を更新（トークン監査用）
+                    if (tokenId != null) {
+                        ServiceAccountTokenRepository.updateLastUsedAtBlocking(tokenId)
+                    }
 
-                JWTPrincipal(credential.payload)
+                    span.setAttribute(TelemetryAttributes.AUTH_RESULT, "valid")
+                    JWTPrincipal(credential.payload)
+                }
             }
             challenge { _, _ ->
                 call.respond(HttpStatusCode.Unauthorized, "Service token is not valid or has expired")
@@ -222,7 +265,7 @@ internal fun Application.module() {
         // Prometheusメトリクスエンドポイント（metricsEnabledが有効な場合のみ）
         if (observabilityConfig.metricsEnabled) {
             get("/metrics") {
-                call.respond(appMicrometerRegistry.scrape())
+                call.respond(prometheusRegistry.scrape())
             }
         }
 

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/AuthorizeRouter.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/AuthorizeRouter.kt
@@ -5,6 +5,7 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.velocity.*
+import io.opentelemetry.api.trace.Span
 import java.security.SecureRandom
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -20,6 +21,8 @@ import party.morino.mineauth.core.web.router.auth.oauth.OAuthValidation.buildErr
 import party.morino.mineauth.core.web.router.auth.oauth.OAuthValidation.buildSuccessRedirectUri
 import party.morino.mineauth.core.web.router.auth.oauth.OAuthValidation.validatePKCE
 import party.morino.mineauth.core.web.router.auth.oauth.OAuthValidation.validateScope
+import party.morino.mineauth.core.web.telemetry.TelemetryAttributes
+import party.morino.mineauth.core.web.telemetry.withSpan
 
 /**
  * OAuth2.0の認可エンドポイントを提供するルーター
@@ -52,6 +55,10 @@ object AuthorizeRouter: KoinComponent {
             val codeChallengeMethod = call.parameters["code_challenge_method"]
             // OIDC nonce: リプレイ攻撃防止用（任意パラメータ）
             val nonce = call.parameters["nonce"]
+
+            // テレメトリ: サーバースパンにクライアントID・スコープを記録する
+            clientId?.let { Span.current().setAttribute(TelemetryAttributes.CLIENT_ID, it) }
+            scope?.let { Span.current().setAttribute(TelemetryAttributes.OAUTH_SCOPE, it) }
 
             // RFC 6749 Section 4.1.2.1: client_idまたはredirect_uriが不正/欠落の場合は400
             // これらが不正な場合はリダイレクトしてはならない（オープンリダイレクタ防止）
@@ -143,6 +150,10 @@ object AuthorizeRouter: KoinComponent {
             // OIDC nonce: リプレイ攻撃防止用（任意パラメータ）
             val nonce = formParameters["nonce"]
 
+            // テレメトリ: サーバースパンにクライアントID・スコープを記録する（ユーザー名・パスワードは記録しない）
+            clientId?.let { Span.current().setAttribute(TelemetryAttributes.CLIENT_ID, it) }
+            scope?.let { Span.current().setAttribute(TelemetryAttributes.OAUTH_SCOPE, it) }
+
             // パラメータのバリデーション
             if (username == null || password == null || responseType != "code" || clientId == null || redirectUri == null || scope == null || state == null || codeChallenge == null) {
                 // redirect_uriとstateが存在する場合のみエラーリダイレクト
@@ -178,8 +189,16 @@ object AuthorizeRouter: KoinComponent {
                 return@post
             }
 
-            // ユーザー認証
-            val authResult = OAuthService.authenticateUser(username, password)
+            // ユーザー認証（結果をスパンとして記録する。ユーザー名・パスワードは記録しない）
+            val authResult = withSpan("oauth.user.authenticate") { span ->
+                OAuthService.authenticateUser(username, password).also { result ->
+                    val resultLabel = when (result) {
+                        is AuthenticationResult.Success -> "success"
+                        is AuthenticationResult.Failed -> result.reason.name.lowercase()
+                    }
+                    span.setAttribute(TelemetryAttributes.AUTH_RESULT, resultLabel)
+                }
+            }
             val uniqueId = when (authResult) {
                 is AuthenticationResult.Success -> authResult.uniqueId
                 is AuthenticationResult.Failed -> {
@@ -193,6 +212,9 @@ object AuthorizeRouter: KoinComponent {
                     return@post
                 }
             }
+
+            // テレメトリ: 認証成功したプレイヤーUUIDを記録する
+            Span.current().setAttribute(TelemetryAttributes.PLAYER_UUID, uniqueId.toString())
 
             // 認可コードの生成と保存
             // スコープ文字列を正規化（余分な空白を除去してから保存）

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/EndSessionRouter.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/EndSessionRouter.kt
@@ -4,11 +4,13 @@ import com.auth0.jwt.exceptions.JWTVerificationException
 import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.opentelemetry.api.trace.Span
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import party.morino.mineauth.core.MineAuth
 import party.morino.mineauth.core.file.utils.JwtProvider
 import party.morino.mineauth.core.web.components.auth.ClientData
+import party.morino.mineauth.core.web.telemetry.TelemetryAttributes
 
 /**
  * OpenID Connect RP-Initiated Logout 1.0 エンドポイント
@@ -46,6 +48,8 @@ object EndSessionRouter : KoinComponent {
                     call.respondOAuthError(OAuthErrorCode.INVALID_REQUEST, "Invalid id_token_hint")
                     return@get
                 }
+                // テレメトリ: 検証済みクライアントIDをサーバースパンに記録する
+                Span.current().setAttribute(TelemetryAttributes.CLIENT_ID, validatedClientId)
             }
 
             // post_logout_redirect_uriが提供された場合、登録済みURIとの一致を検証

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/IntrospectRouter.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/IntrospectRouter.kt
@@ -14,6 +14,8 @@ import party.morino.mineauth.core.file.utils.JwtProvider
 import party.morino.mineauth.core.repository.RevokedTokenRepository
 import party.morino.mineauth.core.web.router.auth.oauth.OAuthValidation.authenticateConfidentialClient
 import party.morino.mineauth.core.web.router.auth.oauth.OAuthValidation.extractClientCredentials
+import party.morino.mineauth.core.web.telemetry.TelemetryAttributes
+import party.morino.mineauth.core.web.telemetry.withSpan
 
 /**
  * RFC 7662 OAuth 2.0 Token Introspection エンドポイント
@@ -51,16 +53,24 @@ object IntrospectRouter : KoinComponent {
                 }
                 is Either.Right -> result.value
             }
-            when (val result = authenticateConfidentialClient(credentials)) {
+            val authenticated = withSpan("oauth.client.authenticate") { span ->
+                span.setAttribute(TelemetryAttributes.CLIENT_ID, credentials.clientId)
+                authenticateConfidentialClient(credentials)
+            }
+            when (authenticated) {
                 is Either.Left -> {
-                    call.respondOAuthError(result.value.errorCode, result.value.message)
+                    call.respondOAuthError(authenticated.value.errorCode, authenticated.value.message)
                     return@post
                 }
                 is Either.Right -> { /* 認証成功 */ }
             }
 
-            // トークンを検証してイントロスペクションレスポンスを生成
-            val response = introspectToken(token)
+            // トークンを検証してイントロスペクションレスポンスを生成（結果のactiveを記録する）
+            val response = withSpan("oauth.introspect") { span ->
+                introspectToken(token).also {
+                    span.setAttribute(TelemetryAttributes.AUTH_RESULT, if (it.active) "active" else "inactive")
+                }
+            }
 
             // RFC 7662 Section 2.2: 常に200 OKで返す
             call.respond(HttpStatusCode.OK, response)

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/OAuthError.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/OAuthError.kt
@@ -4,11 +4,14 @@ import io.ktor.http.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.StatusCode
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import party.morino.mineauth.core.MineAuth
+import party.morino.mineauth.core.web.telemetry.TelemetryAttributes
 
 /**
  * OAuth 2.0 エラーレスポンス
@@ -112,6 +115,12 @@ suspend fun RoutingCall.respondOAuthError(
     val logMessage = "OAuth error at $endpoint: ${errorCode.code}" +
         (description?.let { " - $it" } ?: "")
     OAuthErrorLogger.plugin.logger.warning(logMessage)
+
+    // テレメトリ: 現在のスパンにエラーコードを記録する（全OAuthエラーパスの中央フック）
+    // トレーシング無効時はNoOp Spanになるため安全
+    Span.current()
+        .setAttribute(TelemetryAttributes.OAUTH_ERROR_CODE, errorCode.code)
+        .setStatus(StatusCode.ERROR)
 
     respond(statusCode, errorCode.toResponse(description))
 }

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/OAuthService.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/OAuthService.kt
@@ -13,6 +13,7 @@ import party.morino.mineauth.core.web.components.auth.ClientData
 import party.morino.mineauth.core.web.router.auth.common.AuthenticationError
 import party.morino.mineauth.core.web.router.auth.common.AuthenticationResult
 import party.morino.mineauth.core.web.router.auth.common.AuthenticationService
+import party.morino.mineauth.core.web.telemetry.withDatabaseSpan
 import java.util.*
 
 object OAuthService : AuthenticationService, KoinComponent {
@@ -24,15 +25,19 @@ object OAuthService : AuthenticationService, KoinComponent {
         }
         
         val uniqueId = offlinePlayer.uniqueId
-        val exist = newSuspendedTransaction(Dispatchers.IO) {
-            UserAuthData.selectAll().where { uuid eq uniqueId.toString() }.count() > 0
+        val exist = withDatabaseSpan("user_auth_data", "select") {
+            newSuspendedTransaction(Dispatchers.IO) {
+                UserAuthData.selectAll().where { uuid eq uniqueId.toString() }.count() > 0
+            }
         }
         if (!exist) {
             return AuthenticationResult.Failed(AuthenticationError.PLAYER_NOT_REGISTERED)
         }
-        
-        val hashedPassword = newSuspendedTransaction {
-            UserAuthData.selectAll().where { uuid eq uniqueId.toString() }.first()[UserAuthData.password]
+
+        val hashedPassword = withDatabaseSpan("user_auth_data", "select") {
+            newSuspendedTransaction {
+                UserAuthData.selectAll().where { uuid eq uniqueId.toString() }.first()[UserAuthData.password]
+            }
         }
         val check = Password.check(password, hashedPassword).addPepper().withArgon2()
         if (!check) {

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/ProfileRouter.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/ProfileRouter.kt
@@ -4,6 +4,7 @@ import io.ktor.server.auth.*
 import io.ktor.server.auth.jwt.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.opentelemetry.api.trace.Span
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import party.morino.mineauth.core.file.data.MineAuthConfig
@@ -11,6 +12,7 @@ import party.morino.mineauth.core.integration.luckperms.LuckPermsIntegration
 import party.morino.mineauth.core.utils.PlayerUtils.toOfflinePlayer
 import party.morino.mineauth.core.utils.PlayerUtils.toUUID
 import party.morino.mineauth.core.web.components.auth.UserInfoResponse
+import party.morino.mineauth.core.web.telemetry.TelemetryAttributes
 
 /**
  * OpenID Connect UserInfo Endpoint
@@ -31,6 +33,9 @@ object ProfileRouter : KoinComponent {
                 val playerUniqueId = payload.getClaim("playerUniqueId").asString().toUUID()
                 val offlinePlayer = playerUniqueId.toOfflinePlayer()
                 val username = offlinePlayer.name ?: "Unknown"
+
+                // テレメトリ: サーバースパンにプレイヤーUUID・スコープを記録する
+                Span.current().setAttribute(TelemetryAttributes.PLAYER_UUID, playerUniqueId.toString())
 
                 // JWTからスコープを取得してリストに変換
                 val scopeString = payload.getClaim("scope").asString() ?: ""

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/RevokeRouter.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/RevokeRouter.kt
@@ -16,6 +16,8 @@ import party.morino.mineauth.core.repository.RevokedTokenRepository
 import party.morino.mineauth.core.repository.TokenType
 import party.morino.mineauth.core.web.router.auth.oauth.OAuthValidation.authenticateConfidentialClient
 import party.morino.mineauth.core.web.router.auth.oauth.OAuthValidation.extractClientCredentials
+import party.morino.mineauth.core.web.telemetry.TelemetryAttributes
+import party.morino.mineauth.core.web.telemetry.withSpan
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -59,16 +61,24 @@ object RevokeRouter : KoinComponent {
                 }
                 is Either.Right -> result.value
             }
-            val clientData = when (val result = authenticateConfidentialClient(credentials)) {
+            val authenticated = withSpan("oauth.client.authenticate") { span ->
+                span.setAttribute(TelemetryAttributes.CLIENT_ID, credentials.clientId)
+                authenticateConfidentialClient(credentials)
+            }
+            val clientData = when (authenticated) {
                 is Either.Left -> {
-                    call.respondOAuthError(result.value.errorCode, result.value.message)
+                    call.respondOAuthError(authenticated.value.errorCode, authenticated.value.message)
                     return@post
                 }
-                is Either.Right -> result.value
+                is Either.Right -> authenticated.value
             }
 
-            // トークンの検証と失効処理
-            val revocationResult = revokeToken(token, tokenTypeHint, clientData.clientId)
+            // トークンの検証と失効処理（クライアントID・種別ヒントを記録する。トークン本体は記録しない）
+            val revocationResult = withSpan("oauth.revoke") { span ->
+                span.setAttribute(TelemetryAttributes.CLIENT_ID, clientData.clientId)
+                tokenTypeHint?.let { span.setAttribute(TelemetryAttributes.TOKEN_TYPE_HINT, it) }
+                revokeToken(token, tokenTypeHint, clientData.clientId)
+            }
 
             // RFC 7009 Section 2.2:
             // 成功時は200 OKを返す（トークンの有効性に関わらず）

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/TokenRouter.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/TokenRouter.kt
@@ -6,6 +6,7 @@ import io.ktor.http.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.opentelemetry.api.common.Attributes
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import org.koin.core.component.inject
@@ -23,6 +24,8 @@ import party.morino.mineauth.core.web.router.auth.oauth.OAuthValidation.extractC
 import party.morino.mineauth.core.web.router.auth.oauth.OAuthValidation.validateCodeVerifier
 import party.morino.mineauth.core.repository.RevokedTokenRepository
 import party.morino.mineauth.core.repository.TokenType
+import party.morino.mineauth.core.web.telemetry.TelemetryAttributes
+import party.morino.mineauth.core.web.telemetry.withSpan
 import java.security.MessageDigest
 import java.util.*
 
@@ -34,165 +37,198 @@ object TokenRouter: KoinComponent {
 
     fun Route.tokenRouter() {
         post("/token") {
-            val formParameters = call.receiveParameters()
-            val grantType = formParameters["grant_type"]
+            // トークンエンドポイント全体をスパンで計測する
+            withSpan("oauth.token") { span ->
+                val formParameters = call.receiveParameters()
+                val grantType = formParameters["grant_type"]
 
-            // RFC 6749 Section 5.2: grant_type欠如はinvalid_request
-            if (grantType == null) {
-                call.respondOAuthError(OAuthErrorCode.INVALID_REQUEST, "Missing required parameter: grant_type")
-                return@post
-            }
-
-            // クレデンシャル抽出（Basic認証 + フォームパラメータ、併用禁止チェック含む）
-            val credentials = when (val result = extractClientCredentials(formParameters)) {
-                is Either.Left -> {
-                    call.respondOAuthError(result.value.errorCode, result.value.message)
-                    return@post
+                // RFC 6749 Section 5.2: grant_type欠如はinvalid_request
+                if (grantType == null) {
+                    call.respondOAuthError(OAuthErrorCode.INVALID_REQUEST, "Missing required parameter: grant_type")
+                    return@withSpan
                 }
-                is Either.Right -> result.value
-            }
+                span.setAttribute(TelemetryAttributes.OAUTH_GRANT_TYPE, grantType)
 
-            if (grantType == "refresh_token") {
-                //refresh_tokenの処理 https://tools.ietf.org/html/rfc6749#section-6
-                // クライアント認証（Confidential/Public両対応）
-                val clientData = when (val result = authenticateClient(credentials)) {
+                // クレデンシャル抽出（Basic認証 + フォームパラメータ、併用禁止チェック含む）
+                val credentials = when (val result = extractClientCredentials(formParameters)) {
                     is Either.Left -> {
                         call.respondOAuthError(result.value.errorCode, result.value.message)
-                        return@post
+                        return@withSpan
                     }
                     is Either.Right -> result.value
                 }
-                val clientId = clientData.clientId
+                span.setAttribute(TelemetryAttributes.CLIENT_ID, credentials.clientId)
 
-                val refreshToken = formParameters["refresh_token"]
-                if (refreshToken == null) {
-                    call.respondOAuthError(OAuthErrorCode.INVALID_REQUEST, "Missing required parameter: refresh_token")
-                    return@post
-                }
-
-                // リフレッシュトークンの検証（署名・有効期限・token_type）
-                val verified = verifyAndDecodeRefreshToken(refreshToken)
-                if (verified == null) {
-                    call.respondOAuthError(OAuthErrorCode.INVALID_GRANT, "Invalid or expired refresh token")
-                    return@post
-                }
-
-                // クライアントIDの一致を確認
-                if (verified.authorizedData.clientId != clientId) {
-                    call.respondOAuthError(OAuthErrorCode.INVALID_GRANT, "Refresh token was not issued to this client")
-                    return@post
-                }
-
-                // リフレッシュトークン内のスコープを再検証（許可リスト変更に対応）
-                if (!OAuthScope.isValid(verified.authorizedData.scope)) {
-                    call.respondOAuthError(OAuthErrorCode.INVALID_SCOPE, "Refresh token contains invalid scope(s)")
-                    return@post
-                }
-
-                // RFC 6749 Section 10.4: リフレッシュトークンローテーション
-                // 旧トークンの失効を先に行い、失敗時はトークン発行を中止する
-                if (!revokeOldRefreshToken(verified.tokenId, verified.expiresAt, clientId)) {
-                    call.respondOAuthError(OAuthErrorCode.SERVER_ERROR, "Failed to rotate refresh token")
-                    return@post
-                }
-                val token = issueToken(verified.authorizedData, clientId)
-                val newRefreshToken = issueRefreshToken(verified.authorizedData, clientId)
-
-                // refresh_token使用時はID Tokenを発行しない（OIDC一般慣行）
-                // ID Tokenはユーザー認証を表し、refresh_tokenはセッション継続のみ
-                // RFC 6749 Section 5.1: トークンレスポンスにキャッシュ禁止ヘッダーを付与
-                call.response.header(HttpHeaders.CacheControl, "no-store")
-                call.response.header(HttpHeaders.Pragma, "no-cache")
-                call.respond(HttpStatusCode.OK, TokenData(
-                    accessToken = token,
-                    tokenType = "Bearer",
-                    expiresIn = EXPIRES_IN,
-                    refreshToken = newRefreshToken,
-                    idToken = null,
-                    scope = verified.authorizedData.scope
-                ))
-            }else if (grantType == "authorization_code") {
-                //authorization_codeの処理 https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
-                // 期限切れ認可コードの遅延クリーンアップ（リクエスト契機で実行）
-                OAuthRouter.cleanupExpiredCodes(AUTHORIZATION_CODE_LIFETIME_MS)
-                val code = formParameters["code"]
-                val redirectUri = formParameters["redirect_uri"]
-                val codeVerifier = formParameters["code_verifier"]
-                val clientId = credentials.clientId
-
-                // RFC 6749 Section 5.2: 必須パラメータの欠如はinvalid_requestで返す
-                // 認可コード参照より先にチェックし、不要なデータ消費を防ぐ
-                val missingParams = buildList {
-                    if (code == null) add("code")
-                    if (redirectUri == null) add("redirect_uri")
-                    if (codeVerifier == null) add("code_verifier")
-                }
-                if (missingParams.isNotEmpty()) {
-                    call.respondOAuthError(OAuthErrorCode.INVALID_REQUEST, "Missing required parameters: ${missingParams.joinToString(", ")}")
-                    return@post
-                }
-
-                // クライアント認証（Confidential/Public両対応）
-                val clientData = when (val result = authenticateClient(credentials)) {
-                    is Either.Left -> {
-                        call.respondOAuthError(result.value.errorCode, result.value.message)
-                        return@post
+                if (grantType == "refresh_token") {
+                    //refresh_tokenの処理 https://tools.ietf.org/html/rfc6749#section-6
+                    // クライアント認証（Confidential/Public両対応）
+                    val authenticated = withSpan("oauth.client.authenticate") { authenticateClient(credentials) }
+                    val clientData = when (authenticated) {
+                        is Either.Left -> {
+                            call.respondOAuthError(authenticated.value.errorCode, authenticated.value.message)
+                            return@withSpan
+                        }
+                        is Either.Right -> authenticated.value
                     }
-                    is Either.Right -> result.value
-                }
+                    val clientId = clientData.clientId
 
-                // ConcurrentHashMap.removeで取得と削除を原子的に行い、並行リクエストによる二重使用を防止
-                val data = authorizedData.remove(code) ?: run {
-                    call.respondOAuthError(OAuthErrorCode.INVALID_GRANT, "The authorization code is invalid or expired")
-                    return@post
-                }
+                    val refreshToken = formParameters["refresh_token"]
+                    if (refreshToken == null) {
+                        call.respondOAuthError(OAuthErrorCode.INVALID_REQUEST, "Missing required parameter: refresh_token")
+                        return@withSpan
+                    }
 
-                // RFC 6749 Section 4.1.2: 認可コードの有効期限チェック（最大10分）
-                val codeAge = System.currentTimeMillis() - data.authTime
-                if (codeAge > AUTHORIZATION_CODE_LIFETIME_MS) {
-                    call.respondOAuthError(OAuthErrorCode.INVALID_GRANT, "The authorization code has expired")
-                    return@post
-                }
+                    // リフレッシュトークンの検証（署名・有効期限・token_type）
+                    val verified = withSpan("oauth.refresh_token.verify") { verifyAndDecodeRefreshToken(refreshToken) }
+                    if (verified == null) {
+                        call.respondOAuthError(OAuthErrorCode.INVALID_GRANT, "Invalid or expired refresh token")
+                        return@withSpan
+                    }
+                    span.setAttribute(TelemetryAttributes.OAUTH_SCOPE, verified.authorizedData.scope)
+                    span.setAttribute(TelemetryAttributes.PLAYER_UUID, verified.authorizedData.uniqueId.toString())
 
-                // nullチェック済みのためnon-null変数に再代入
-                val validRedirectUri = redirectUri!!
-                val validCodeVerifier = codeVerifier!!
+                    // クライアントIDの一致を確認
+                    if (verified.authorizedData.clientId != clientId) {
+                        call.respondOAuthError(OAuthErrorCode.INVALID_GRANT, "Refresh token was not issued to this client")
+                        return@withSpan
+                    }
 
-                if (data.clientId != clientId || data.redirectUri != validRedirectUri) {
-                    call.respondOAuthError(OAuthErrorCode.INVALID_GRANT, "Invalid client_id or redirect_uri")
-                    return@post
-                }
+                    // リフレッシュトークン内のスコープを再検証（許可リスト変更に対応）
+                    if (!OAuthScope.isValid(verified.authorizedData.scope)) {
+                        call.respondOAuthError(OAuthErrorCode.INVALID_SCOPE, "Refresh token contains invalid scope(s)")
+                        return@withSpan
+                    }
 
-                if (!validateCodeVerifier(data.codeChallenge, validCodeVerifier)) {
-                    call.respondOAuthError(OAuthErrorCode.INVALID_GRANT, "The code_verifier is invalid")
-                    return@post
-                }
+                    // RFC 6749 Section 10.4: リフレッシュトークンローテーション
+                    // 旧トークンの失効を先に行い、失敗時はトークン発行を中止する
+                    val rotated = withSpan("oauth.refresh_token.rotate") {
+                        revokeOldRefreshToken(verified.tokenId, verified.expiresAt, clientId)
+                    }
+                    if (!rotated) {
+                        call.respondOAuthError(OAuthErrorCode.SERVER_ERROR, "Failed to rotate refresh token")
+                        return@withSpan
+                    }
+                    val token = withSpan("jwt.issue", attributes = tokenTypeAttributes("access")) {
+                        issueToken(verified.authorizedData, clientId)
+                    }
+                    val newRefreshToken = withSpan("jwt.issue", attributes = tokenTypeAttributes("refresh")) {
+                        issueRefreshToken(verified.authorizedData, clientId)
+                    }
 
-                val token = issueToken(data, clientId)
-                val refreshToken = issueRefreshToken(data, clientId)
-                // scopeに"openid"が含まれる場合のみID Tokenを発行（OIDC準拠）
-                val idToken = if (data.scope.contains("openid")) {
-                    issueIdToken(data, clientId, token)
-                } else null
-
-                // RFC 6749 Section 5.1: トークンレスポンスにキャッシュ禁止ヘッダーを付与
-                call.response.header(HttpHeaders.CacheControl, "no-store")
-                call.response.header(HttpHeaders.Pragma, "no-cache")
-                call.respond(
-                    HttpStatusCode.OK, TokenData(
+                    // refresh_token使用時はID Tokenを発行しない（OIDC一般慣行）
+                    // ID Tokenはユーザー認証を表し、refresh_tokenはセッション継続のみ
+                    // RFC 6749 Section 5.1: トークンレスポンスにキャッシュ禁止ヘッダーを付与
+                    call.response.header(HttpHeaders.CacheControl, "no-store")
+                    call.response.header(HttpHeaders.Pragma, "no-cache")
+                    call.respond(HttpStatusCode.OK, TokenData(
                         accessToken = token,
                         tokenType = "Bearer",
                         expiresIn = EXPIRES_IN,
-                        refreshToken = refreshToken,
-                        idToken = idToken,
-                        scope = data.scope
+                        refreshToken = newRefreshToken,
+                        idToken = null,
+                        scope = verified.authorizedData.scope
+                    ))
+                }else if (grantType == "authorization_code") {
+                    //authorization_codeの処理 https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
+                    // 期限切れ認可コードの遅延クリーンアップ（リクエスト契機で実行）
+                    OAuthRouter.cleanupExpiredCodes(AUTHORIZATION_CODE_LIFETIME_MS)
+                    val code = formParameters["code"]
+                    val redirectUri = formParameters["redirect_uri"]
+                    val codeVerifier = formParameters["code_verifier"]
+                    val clientId = credentials.clientId
+
+                    // RFC 6749 Section 5.2: 必須パラメータの欠如はinvalid_requestで返す
+                    // 認可コード参照より先にチェックし、不要なデータ消費を防ぐ
+                    val missingParams = buildList {
+                        if (code == null) add("code")
+                        if (redirectUri == null) add("redirect_uri")
+                        if (codeVerifier == null) add("code_verifier")
+                    }
+                    if (missingParams.isNotEmpty()) {
+                        call.respondOAuthError(OAuthErrorCode.INVALID_REQUEST, "Missing required parameters: ${missingParams.joinToString(", ")}")
+                        return@withSpan
+                    }
+
+                    // クライアント認証（Confidential/Public両対応）
+                    val authenticated = withSpan("oauth.client.authenticate") { authenticateClient(credentials) }
+                    val clientData = when (authenticated) {
+                        is Either.Left -> {
+                            call.respondOAuthError(authenticated.value.errorCode, authenticated.value.message)
+                            return@withSpan
+                        }
+                        is Either.Right -> authenticated.value
+                    }
+
+                    // ConcurrentHashMap.removeで取得と削除を原子的に行い、並行リクエストによる二重使用を防止
+                    val data = authorizedData.remove(code) ?: run {
+                        call.respondOAuthError(OAuthErrorCode.INVALID_GRANT, "The authorization code is invalid or expired")
+                        return@withSpan
+                    }
+                    span.setAttribute(TelemetryAttributes.OAUTH_SCOPE, data.scope)
+                    span.setAttribute(TelemetryAttributes.PLAYER_UUID, data.uniqueId.toString())
+
+                    // RFC 6749 Section 4.1.2: 認可コードの有効期限チェック（最大10分）
+                    val codeAge = System.currentTimeMillis() - data.authTime
+                    if (codeAge > AUTHORIZATION_CODE_LIFETIME_MS) {
+                        call.respondOAuthError(OAuthErrorCode.INVALID_GRANT, "The authorization code has expired")
+                        return@withSpan
+                    }
+
+                    // nullチェック済みのためnon-null変数に再代入
+                    val validRedirectUri = redirectUri!!
+                    val validCodeVerifier = codeVerifier!!
+
+                    if (data.clientId != clientId || data.redirectUri != validRedirectUri) {
+                        call.respondOAuthError(OAuthErrorCode.INVALID_GRANT, "Invalid client_id or redirect_uri")
+                        return@withSpan
+                    }
+
+                    if (!validateCodeVerifier(data.codeChallenge, validCodeVerifier)) {
+                        call.respondOAuthError(OAuthErrorCode.INVALID_GRANT, "The code_verifier is invalid")
+                        return@withSpan
+                    }
+
+                    val token = withSpan("jwt.issue", attributes = tokenTypeAttributes("access")) {
+                        issueToken(data, clientId)
+                    }
+                    val refreshToken = withSpan("jwt.issue", attributes = tokenTypeAttributes("refresh")) {
+                        issueRefreshToken(data, clientId)
+                    }
+                    // scopeに"openid"が含まれる場合のみID Tokenを発行（OIDC準拠）
+                    val idToken = if (data.scope.contains("openid")) {
+                        withSpan("jwt.issue", attributes = tokenTypeAttributes("id")) {
+                            issueIdToken(data, clientId, token)
+                        }
+                    } else null
+
+                    // RFC 6749 Section 5.1: トークンレスポンスにキャッシュ禁止ヘッダーを付与
+                    call.response.header(HttpHeaders.CacheControl, "no-store")
+                    call.response.header(HttpHeaders.Pragma, "no-cache")
+                    call.respond(
+                        HttpStatusCode.OK, TokenData(
+                            accessToken = token,
+                            tokenType = "Bearer",
+                            expiresIn = EXPIRES_IN,
+                            refreshToken = refreshToken,
+                            idToken = idToken,
+                            scope = data.scope
+                        )
                     )
-                )
-            }else{
-                call.respondOAuthError(OAuthErrorCode.UNSUPPORTED_GRANT_TYPE, "The grant_type is not supported")
+                }else{
+                    call.respondOAuthError(OAuthErrorCode.UNSUPPORTED_GRANT_TYPE, "The grant_type is not supported")
+                }
             }
         }
     }
+
+    /**
+     * jwt.issueスパン用のトークン種別属性を生成する
+     *
+     * @param tokenType トークンの種類（access / refresh / id）
+     * @return トークン種別属性
+     */
+    private fun tokenTypeAttributes(tokenType: String): Attributes =
+        Attributes.of(TelemetryAttributes.TOKEN_TYPE, tokenType)
 
     private fun issueToken(
         data: AuthorizedData, clientId: String?

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/MinecraftMetrics.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/MinecraftMetrics.kt
@@ -1,0 +1,75 @@
+package party.morino.mineauth.core.web.telemetry
+
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.binder.MeterBinder
+import org.bukkit.Bukkit
+
+/**
+ * Minecraftサーバーのメトリクスを提供するMeterBinder
+ *
+ * 全てpull型のゲージとして登録するため、Bukkitスケジューラのタスクは不要。
+ * ゲージの値はスクレイプ/エクスポート時（exporterスレッド）に評価されるので、
+ * メインスレッド外から安全に読めるPaperのカウンタAPIのみを使用する。
+ * （getLoadedChunks()やgetEntities()のようなコレクションのイテレートは禁止）
+ *
+ * ワールド別のゲージはbind時点に存在するワールドに対してのみ登録される。
+ * bind後にロードされたワールドは対象外（v1の制約）。
+ */
+class MinecraftMetrics : MeterBinder {
+    override fun bindTo(registry: MeterRegistry) {
+        // オンラインプレイヤー数
+        Gauge.builder("minecraft.players.online") { Bukkit.getOnlinePlayers().size }
+            .description("Number of online players")
+            .baseUnit("{player}")
+            .register(registry)
+
+        // 最大プレイヤー数
+        Gauge.builder("minecraft.players.max") { Bukkit.getMaxPlayers() }
+            .description("Maximum number of players")
+            .baseUnit("{player}")
+            .register(registry)
+
+        // TPS（1分・5分・15分の移動平均をwindowタグで区別する）
+        listOf("1m" to 0, "5m" to 1, "15m" to 2).forEach { (window, index) ->
+            Gauge.builder("minecraft.server.tps") { Bukkit.getTPS().getOrElse(index) { 0.0 } }
+                .description("Server ticks per second")
+                .tag("window", window)
+                .register(registry)
+        }
+
+        // 平均tick処理時間（MSPT）
+        Gauge.builder("minecraft.server.tick.duration.average") { Bukkit.getAverageTickTime() }
+            .description("Average tick duration (MSPT)")
+            .baseUnit("ms")
+            .register(registry)
+
+        // ロード済みワールド数
+        Gauge.builder("minecraft.worlds.count") { Bukkit.getWorlds().size }
+            .description("Number of loaded worlds")
+            .baseUnit("{world}")
+            .register(registry)
+
+        // ワールド別のエンティティ数・ロード済みチャンク数
+        // Paperのカウンタアクセサ（単なるフィールド読み取り）のみを使うこと
+        Bukkit.getWorlds().forEach { world ->
+            val worldName = world.name
+
+            Gauge.builder("minecraft.entities.count") {
+                Bukkit.getWorld(worldName)?.entityCount ?: 0
+            }
+                .description("Number of entities in the world")
+                .baseUnit("{entity}")
+                .tag("world", worldName)
+                .register(registry)
+
+            Gauge.builder("minecraft.chunks.loaded") {
+                Bukkit.getWorld(worldName)?.chunkCount ?: 0
+            }
+                .description("Number of loaded chunks in the world")
+                .baseUnit("{chunk}")
+                .tag("world", worldName)
+                .register(registry)
+        }
+    }
+}

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/TelemetryAttributes.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/TelemetryAttributes.kt
@@ -1,0 +1,79 @@
+package party.morino.mineauth.core.web.telemetry
+
+import io.opentelemetry.api.common.AttributeKey
+
+/**
+ * MineAuthのテレメトリで使用するカスタム属性キーの定義
+ *
+ * OpenTelemetryのsemconvに存在しない属性（incubating属性やMineAuth固有の属性）を
+ * ここに集約して定義する。incubating semconvアーティファクトへの依存を避けるため、
+ * 標準名（service.namespace, host.name, db.*）も素のAttributeKeyとして定義している。
+ *
+ * PIIポリシー:
+ * - プレイヤーUUIDは擬似匿名IDのため属性として許可（トレースの相関に必要）
+ * - ユーザー名・パスワード・クライアントシークレット・トークン・認可コード・code_verifierは記録禁止
+ */
+object TelemetryAttributes {
+    // ===== リソース属性 =====
+
+    // サービスの論理グループ名（複数サーバー運用時の識別用）
+    val SERVICE_NAMESPACE: AttributeKey<String> = AttributeKey.stringKey("service.namespace")
+
+    // ホスト名
+    val HOST_NAME: AttributeKey<String> = AttributeKey.stringKey("host.name")
+
+    // Minecraftのバージョン（例: 1.21.11）
+    val MINECRAFT_VERSION: AttributeKey<String> = AttributeKey.stringKey("minecraft.version")
+
+    // サーバー実装名（例: Paper）
+    val MINECRAFT_SERVER_BRAND: AttributeKey<String> = AttributeKey.stringKey("minecraft.server.brand")
+
+    // プラグイン名
+    val MINECRAFT_PLUGIN_NAME: AttributeKey<String> = AttributeKey.stringKey("minecraft.plugin.name")
+
+    // ===== スパン属性（MineAuth固有） =====
+
+    // OAuthクライアントID（非シークレット）
+    val CLIENT_ID: AttributeKey<String> = AttributeKey.stringKey("mineauth.client.id")
+
+    // OAuthグラントタイプ（authorization_code / refresh_token など）
+    val OAUTH_GRANT_TYPE: AttributeKey<String> = AttributeKey.stringKey("mineauth.oauth.grant_type")
+
+    // OAuthスコープ
+    val OAUTH_SCOPE: AttributeKey<String> = AttributeKey.stringKey("mineauth.oauth.scope")
+
+    // プレイヤーUUID（擬似匿名ID）
+    val PLAYER_UUID: AttributeKey<String> = AttributeKey.stringKey("mineauth.player.uuid")
+
+    // 発行するトークンの種類（access / refresh / id）
+    val TOKEN_TYPE: AttributeKey<String> = AttributeKey.stringKey("mineauth.token.type")
+
+    // 認証・検証の結果（valid / revoked / client_not_found / wrong_token_type など）
+    val AUTH_RESULT: AttributeKey<String> = AttributeKey.stringKey("mineauth.auth.result")
+
+    // OAuthエラーコード（invalid_grant / invalid_client など）
+    val OAUTH_ERROR_CODE: AttributeKey<String> = AttributeKey.stringKey("mineauth.oauth.error_code")
+
+    // アドオンルートのハンドラークラス名（どのアドオンの処理か識別する）
+    val HANDLER_CLASS: AttributeKey<String> = AttributeKey.stringKey("mineauth.handler.class")
+
+    // アドオンルートのエンドポイントパス
+    val ENDPOINT_PATH: AttributeKey<String> = AttributeKey.stringKey("mineauth.endpoint.path")
+
+    // アドオンルートのHTTPメソッド
+    val ENDPOINT_METHOD: AttributeKey<String> = AttributeKey.stringKey("mineauth.endpoint.method")
+
+    // トークン種別ヒント（introspect / revokeのtoken_type_hint）
+    val TOKEN_TYPE_HINT: AttributeKey<String> = AttributeKey.stringKey("mineauth.token.type_hint")
+
+    // ===== DB属性（semconv準拠の名前） =====
+
+    // データベースシステム名（sqlite / mysql）
+    val DB_SYSTEM_NAME: AttributeKey<String> = AttributeKey.stringKey("db.system.name")
+
+    // 実行する操作名（select / insert / update / delete）
+    val DB_OPERATION_NAME: AttributeKey<String> = AttributeKey.stringKey("db.operation.name")
+
+    // 対象テーブル名
+    val DB_COLLECTION_NAME: AttributeKey<String> = AttributeKey.stringKey("db.collection.name")
+}

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/TelemetryProvider.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/TelemetryProvider.kt
@@ -3,13 +3,19 @@ package party.morino.mineauth.core.web.telemetry
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.metrics.Meter
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
 import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.metrics.export.MetricExporter
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.ReadWriteSpan
 import io.opentelemetry.sdk.trace.ReadableSpan
@@ -18,13 +24,16 @@ import io.opentelemetry.sdk.trace.SpanProcessor
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
 import io.opentelemetry.sdk.trace.export.SpanExporter
 import io.opentelemetry.semconv.ServiceAttributes
+import org.bukkit.Bukkit
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import party.morino.mineauth.core.MineAuth
 import party.morino.mineauth.core.file.data.ObservabilityConfig
 import party.morino.mineauth.core.file.data.OtlpExporterConfig
 import party.morino.mineauth.core.file.data.OtlpExporterProtocol
+import java.net.InetAddress
 import java.net.URI
+import java.time.Duration
 
 /**
  * OpenTelemetryのプロバイダークラス
@@ -34,6 +43,7 @@ object TelemetryProvider : KoinComponent {
     private val plugin: MineAuth by inject()
     private var openTelemetry: OpenTelemetry? = null
     private var sdkTracerProvider: SdkTracerProvider? = null
+    private var sdkMeterProvider: SdkMeterProvider? = null
 
     /**
      * OpenTelemetryを初期化する
@@ -82,15 +92,8 @@ object TelemetryProvider : KoinComponent {
             }
         }
 
-        // リソース属性（サービス名など）を設定
-        val resource = Resource.getDefault()
-            .merge(
-                Resource.create(
-                    Attributes.of(
-                        ServiceAttributes.SERVICE_NAME, config.serviceName
-                    )
-                )
-            )
+        // リソース属性（サービス名・バージョン・ホスト・Minecraft情報）を設定
+        val resource = Resource.getDefault().merge(Resource.create(buildResourceAttributes(config)))
 
         // セキュリティ: UUID等の機密情報をマスクするSpanProcessor
         val sanitizingProcessor = SanitizingSpanProcessor()
@@ -111,14 +114,71 @@ object TelemetryProvider : KoinComponent {
         sdkTracerProvider = tracerProvider
 
         // OpenTelemetry SDKを作成
-        val sdk = OpenTelemetrySdk.builder()
+        val sdkBuilder = OpenTelemetrySdk.builder()
             .setTracerProvider(tracerProvider)
             .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
-            .build()
+
+        // OTLPメトリクスが有効な場合はMeterProviderを構築して配線
+        if (config.otlpMetricsEnabled) {
+            val meterProviderBuilder = SdkMeterProvider.builder().setResource(resource)
+
+            // 各エクスポーターに対して定期エクスポート用のMetricReaderを登録
+            config.exporters.forEach { exporterConfig ->
+                val metricReader = PeriodicMetricReader.builder(createMetricExporter(exporterConfig))
+                    .setInterval(Duration.ofSeconds(config.metricExportIntervalSeconds))
+                    .build()
+                meterProviderBuilder.registerMetricReader(metricReader)
+            }
+
+            val meterProvider = meterProviderBuilder.build()
+            sdkMeterProvider = meterProvider
+            sdkBuilder.setMeterProvider(meterProvider)
+        }
+
+        val sdk = sdkBuilder.build()
 
         openTelemetry = sdk
         plugin.logger.info("OpenTelemetry initialized successfully")
         return sdk
+    }
+
+    /**
+     * リソース属性を構築する
+     * サービス情報に加えて、ホスト名やMinecraftサーバーの情報を付与する
+     *
+     * @param config Observability設定
+     * @return リソース属性
+     */
+    private fun buildResourceAttributes(config: ObservabilityConfig): Attributes {
+        val builder = Attributes.builder()
+            .put(ServiceAttributes.SERVICE_NAME, config.serviceName)
+            .put(TelemetryAttributes.SERVICE_NAMESPACE, config.serviceNamespace)
+
+        // プラグインのメタ情報（バージョン・名前）
+        // テスト環境などでプラグインが取得できない場合はスキップ
+        try {
+            builder.put(ServiceAttributes.SERVICE_VERSION, plugin.pluginMeta.version)
+            builder.put(TelemetryAttributes.MINECRAFT_PLUGIN_NAME, plugin.pluginMeta.name)
+        } catch (e: Exception) {
+            plugin.logger.fine("Could not resolve plugin meta for resource attributes: ${e.message}")
+        }
+
+        // ホスト名（解決に失敗した場合は省略）
+        try {
+            builder.put(TelemetryAttributes.HOST_NAME, InetAddress.getLocalHost().hostName)
+        } catch (e: Exception) {
+            plugin.logger.fine("Could not resolve host name for resource attributes: ${e.message}")
+        }
+
+        // Minecraftサーバー情報（MockBukkit等ではサーバー未初期化の場合があるためガード）
+        try {
+            builder.put(TelemetryAttributes.MINECRAFT_VERSION, Bukkit.getMinecraftVersion())
+            builder.put(TelemetryAttributes.MINECRAFT_SERVER_BRAND, Bukkit.getName())
+        } catch (e: Exception) {
+            plugin.logger.fine("Could not resolve Minecraft server info for resource attributes: ${e.message}")
+        }
+
+        return builder.build()
     }
 
     /**
@@ -130,6 +190,17 @@ object TelemetryProvider : KoinComponent {
     fun getTracer(instrumentationName: String = "mineauth"): Tracer {
         return openTelemetry?.getTracer(instrumentationName)
             ?: OpenTelemetry.noop().getTracer(instrumentationName)
+    }
+
+    /**
+     * メーターを取得する
+     *
+     * @param instrumentationName インストルメンテーション名
+     * @return Meterインスタンス（未初期化の場合はNoOp）
+     */
+    fun getMeter(instrumentationName: String = "mineauth"): Meter {
+        return openTelemetry?.getMeter(instrumentationName)
+            ?: OpenTelemetry.noop().getMeter(instrumentationName)
     }
 
     /**
@@ -187,6 +258,52 @@ object TelemetryProvider : KoinComponent {
     }
 
     /**
+     * OTLPメトリクスエクスポーターを作成する
+     * createSpanExporterと同様にヘッダー設定をサポートして認証付きバックエンドにも対応
+     *
+     * @param config エクスポーター設定
+     * @return 設定済みのMetricExporter
+     */
+    internal fun createMetricExporter(config: OtlpExporterConfig): MetricExporter {
+        // プロトコルに応じてOTLPエクスポーターを切り替える
+        return when (config.protocol) {
+            OtlpExporterProtocol.GRPC -> {
+                // gRPCエクスポーターを構築
+                val builder = OtlpGrpcMetricExporter.builder()
+                    .setEndpoint(config.endpoint)
+                    .setTimeout(Duration.ofSeconds(30)) // タイムアウトを30秒に設定
+
+                // ヘッダーを設定（認証用など）
+                config.headers.forEach { (key, value) ->
+                    builder.addHeader(key, value)
+                }
+
+                builder.build()
+            }
+            OtlpExporterProtocol.HTTP -> {
+                // HTTPエクスポーターを構築
+                // 注意: OtlpHttpMetricExporterは自動的に/v1/metricsを追加する
+                // ユーザーが誤ってシグナル別のパスを含めた場合は除去する
+                val normalizedEndpoint = config.endpoint
+                    .removeSuffix("/v1/metrics")
+                    .removeSuffix("/v1/traces")
+                    .removeSuffix("/")
+
+                val builder = OtlpHttpMetricExporter.builder()
+                    .setEndpoint(normalizedEndpoint)
+                    .setTimeout(Duration.ofSeconds(30)) // タイムアウトを30秒に設定
+
+                // ヘッダーを設定（認証用など）
+                config.headers.forEach { (key, value) ->
+                    builder.addHeader(key, value)
+                }
+
+                builder.build()
+            }
+        }
+    }
+
+    /**
      * シャットダウン処理
      * サーバー停止時に呼び出してリソースを解放する
      */
@@ -202,8 +319,10 @@ object TelemetryProvider : KoinComponent {
      */
     private fun shutdownInternal() {
         sdkTracerProvider?.shutdown()
+        sdkMeterProvider?.shutdown()
         openTelemetry = null
         sdkTracerProvider = null
+        sdkMeterProvider = null
     }
 }
 

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/TracingSupport.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/TracingSupport.kt
@@ -1,0 +1,109 @@
+package party.morino.mineauth.core.web.telemetry
+
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.context.Context
+import io.opentelemetry.extension.kotlin.asContextElement
+import kotlinx.coroutines.withContext
+import org.koin.core.context.GlobalContext
+import party.morino.mineauth.core.file.data.DatabaseConfig
+import party.morino.mineauth.core.file.data.MineAuthConfig
+
+/**
+ * トレーシング用の再利用ヘルパー
+ *
+ * 生のOpenTelemetry APIをアプリケーションコードに散乱させず、
+ * このファイルのヘルパー経由でスパンを作成する。
+ * トレーシングが無効の場合はNoOp Tracerが返るため、安全に呼び出せる。
+ */
+
+/**
+ * 指定した名前のスパンを開始してブロックを実行する
+ *
+ * 現在のOpenTelemetry Contextを親としてスパンを作成し、
+ * コルーチンContextにスパンを載せることでsuspend関数を跨いだ親子付けを実現する。
+ * ブロックが例外を投げた場合はスパンに例外を記録し、ステータスをERRORにする。
+ *
+ * @param name スパン名（識別子を含めないこと。属性で表現する）
+ * @param kind スパンの種類（デフォルト: INTERNAL）
+ * @param attributes スパン開始時に設定する属性
+ * @param tracer 使用するTracer（テスト用に差し替え可能）
+ * @param block 実行する処理（スパンを受け取って追加の属性を設定できる）
+ * @return ブロックの戻り値
+ */
+suspend fun <T> withSpan(
+    name: String,
+    kind: SpanKind = SpanKind.INTERNAL,
+    attributes: Attributes = Attributes.empty(),
+    tracer: Tracer = TelemetryProvider.getTracer(),
+    block: suspend (Span) -> T
+): T {
+    // 現在のContextを親としてスパンを開始
+    val span = tracer
+        .spanBuilder(name)
+        .setSpanKind(kind)
+        .setParent(Context.current())
+        .setAllAttributes(attributes)
+        .startSpan()
+
+    return try {
+        // スパンをコルーチンContextに載せて、suspend関数を跨いでも子スパンが正しく紐づくようにする
+        withContext(span.storeInContext(Context.current()).asContextElement()) {
+            block(span)
+        }
+    } catch (e: Throwable) {
+        // 例外を記録してステータスをERRORに設定
+        span.recordException(e)
+        span.setStatus(StatusCode.ERROR)
+        throw e
+    } finally {
+        span.end()
+    }
+}
+
+/**
+ * データベースアクセス用のスパンを開始してブロックを実行する
+ *
+ * スパン名は `db.<テーブル名>.<操作名>` の形式で、semconv準拠のDB属性を設定する。
+ *
+ * @param table 対象テーブル名（例: oauth_clients）
+ * @param operation 操作名（select / insert / update / delete）
+ * @param block 実行するDB処理
+ * @return ブロックの戻り値
+ */
+suspend fun <T> withDatabaseSpan(
+    table: String,
+    operation: String,
+    block: suspend (Span) -> T
+): T {
+    // DB属性を組み立てる（db.system.nameは設定から解決）
+    val attributes = Attributes.builder()
+        .put(TelemetryAttributes.DB_SYSTEM_NAME, resolveDatabaseSystemName())
+        .put(TelemetryAttributes.DB_COLLECTION_NAME, table)
+        .put(TelemetryAttributes.DB_OPERATION_NAME, operation)
+        .build()
+
+    return withSpan("db.$table.$operation", SpanKind.CLIENT, attributes, block = block)
+}
+
+/**
+ * 設定からデータベースシステム名を解決する
+ *
+ * Koinが未初期化・設定未登録の場合（テスト環境など）は "unknown" を返す。
+ *
+ * @return データベースシステム名（sqlite / mysql / unknown）
+ */
+private fun resolveDatabaseSystemName(): String {
+    return try {
+        when (GlobalContext.getOrNull()?.getOrNull<MineAuthConfig>()?.database) {
+            is DatabaseConfig.SQLite -> "sqlite"
+            is DatabaseConfig.MySQL -> "mysql"
+            null -> "unknown"
+        }
+    } catch (e: Exception) {
+        "unknown"
+    }
+}

--- a/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/MinecraftMetricsTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/MinecraftMetricsTest.kt
@@ -1,0 +1,67 @@
+package party.morino.mineauth.core.web.telemetry
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.bukkit.Bukkit
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * MinecraftMetricsのテスト
+ * Bukkitの静的メソッドをmockkでモックしてゲージの登録と値を検証する
+ * （MockBukkitはpaper-apiとのバージョン不整合があるため使用しない）
+ */
+class MinecraftMetricsTest {
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(Bukkit::class)
+        every { Bukkit.getOnlinePlayers() } returns emptyList()
+        every { Bukkit.getMaxPlayers() } returns 20
+        every { Bukkit.getTPS() } returns doubleArrayOf(20.0, 19.5, 19.0)
+        every { Bukkit.getAverageTickTime() } returns 5.0
+        every { Bukkit.getWorlds() } returns emptyList()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(Bukkit::class)
+    }
+
+    @Test
+    @DisplayName("bindTo registers player and server gauges")
+    fun bindToRegistersPlayerAndServerGauges() {
+        val registry = SimpleMeterRegistry()
+
+        MinecraftMetrics().bindTo(registry)
+
+        // 主要なゲージが登録されていることを確認
+        assertNotNull(registry.find("minecraft.players.online").gauge())
+        assertNotNull(registry.find("minecraft.players.max").gauge())
+        assertNotNull(registry.find("minecraft.server.tick.duration.average").gauge())
+        assertNotNull(registry.find("minecraft.worlds.count").gauge())
+
+        // TPSはwindowタグ付きで3つ登録される
+        assertEquals(3, registry.find("minecraft.server.tps").gauges().size)
+    }
+
+    @Test
+    @DisplayName("Gauges reflect server state")
+    fun gaugesReflectServerState() {
+        val registry = SimpleMeterRegistry()
+        MinecraftMetrics().bindTo(registry)
+
+        // モックしたサーバー状態がゲージ値に反映されることを確認
+        assertEquals(0.0, registry.find("minecraft.players.online").gauge()!!.value())
+        assertEquals(20.0, registry.find("minecraft.players.max").gauge()!!.value())
+        assertEquals(20.0, registry.find("minecraft.server.tps").tag("window", "1m").gauge()!!.value())
+        assertEquals(19.0, registry.find("minecraft.server.tps").tag("window", "15m").gauge()!!.value())
+        assertEquals(5.0, registry.find("minecraft.server.tick.duration.average").gauge()!!.value())
+    }
+}

--- a/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/TelemetryProviderTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/TelemetryProviderTest.kt
@@ -1,0 +1,61 @@
+package party.morino.mineauth.core.web.telemetry
+
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import party.morino.mineauth.core.file.data.OtlpExporterConfig
+import party.morino.mineauth.core.file.data.OtlpExporterProtocol
+
+/**
+ * TelemetryProviderのメトリクスエクスポーター生成のテスト
+ * プロトコル切り替えとHTTPエンドポイントの正規化を検証する
+ */
+class TelemetryProviderTest {
+
+    @Test
+    @DisplayName("GRPC protocol creates OtlpGrpcMetricExporter")
+    fun grpcProtocolCreatesGrpcExporter() {
+        val config = OtlpExporterConfig(
+            protocol = OtlpExporterProtocol.GRPC,
+            endpoint = "http://localhost:4317"
+        )
+
+        val exporter = TelemetryProvider.createMetricExporter(config)
+
+        assertTrue(exporter is OtlpGrpcMetricExporter)
+        exporter.shutdown()
+    }
+
+    @Test
+    @DisplayName("HTTP protocol creates OtlpHttpMetricExporter")
+    fun httpProtocolCreatesHttpExporter() {
+        val config = OtlpExporterConfig(
+            protocol = OtlpExporterProtocol.HTTP,
+            endpoint = "http://localhost:4318"
+        )
+
+        val exporter = TelemetryProvider.createMetricExporter(config)
+
+        assertTrue(exporter is OtlpHttpMetricExporter)
+        exporter.shutdown()
+    }
+
+    @Test
+    @DisplayName("HTTP endpoint with signal path suffix is normalized")
+    fun httpEndpointWithSignalPathSuffixIsNormalized() {
+        // ユーザーが誤って/v1/metricsを含めた場合でも二重に付与されないことを確認
+        val config = OtlpExporterConfig(
+            protocol = OtlpExporterProtocol.HTTP,
+            endpoint = "http://localhost:4318/v1/metrics"
+        )
+
+        val exporter = TelemetryProvider.createMetricExporter(config)
+
+        // SDKが/v1/metricsを自動付与するため、二重付与になっていないことを確認
+        assertFalse(exporter.toString().contains("/v1/metrics/v1/metrics"))
+        exporter.shutdown()
+    }
+}

--- a/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/TracingSupportTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/TracingSupportTest.kt
@@ -1,0 +1,86 @@
+package party.morino.mineauth.core.web.telemetry
+
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * withSpanヘルパーのテスト
+ * InMemorySpanExporterを使用してスパンの生成・親子付け・エラーステータスを検証する
+ */
+class TracingSupportTest {
+    // テスト用のインメモリエクスポーターとTracerProvider
+    private val exporter = InMemorySpanExporter.create()
+    private val tracerProvider = SdkTracerProvider.builder()
+        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+        .build()
+    private val tracer = tracerProvider.get("test")
+
+    @AfterEach
+    fun tearDown() {
+        tracerProvider.shutdown()
+    }
+
+    @Test
+    @DisplayName("withSpan creates a span with name and attributes")
+    fun withSpanCreatesSpanWithNameAndAttributes() = runBlocking {
+        val attributes = Attributes.of(TelemetryAttributes.CLIENT_ID, "test-client")
+
+        val result = withSpan("test.span", attributes = attributes, tracer = tracer) { "ok" }
+
+        assertEquals("ok", result)
+        val spans = exporter.finishedSpanItems
+        assertEquals(1, spans.size)
+        assertEquals("test.span", spans[0].name)
+        assertEquals("test-client", spans[0].attributes.get(TelemetryAttributes.CLIENT_ID))
+    }
+
+    @Test
+    @DisplayName("Nested withSpan creates parent-child relationship")
+    fun nestedWithSpanCreatesParentChildRelationship() = runBlocking {
+        withSpan("parent.span", tracer = tracer) {
+            withSpan("child.span", tracer = tracer) { }
+        }
+
+        val spans = exporter.finishedSpanItems
+        assertEquals(2, spans.size)
+        // SimpleSpanProcessorは終了順にエクスポートするため、child → parentの順になる
+        val child = spans.first { it.name == "child.span" }
+        val parent = spans.first { it.name == "parent.span" }
+        assertEquals(parent.spanId, child.parentSpanId)
+        assertEquals(parent.traceId, child.traceId)
+    }
+
+    @Test
+    @DisplayName("withSpan records exception and sets ERROR status")
+    fun withSpanRecordsExceptionAndSetsErrorStatus(): Unit = runBlocking {
+        assertThrows<IllegalStateException> {
+            withSpan("failing.span", tracer = tracer) {
+                throw IllegalStateException("boom")
+            }
+        }
+
+        val spans = exporter.finishedSpanItems
+        assertEquals(1, spans.size)
+        assertEquals(StatusCode.ERROR, spans[0].status.statusCode)
+        // 例外イベントが記録されていることを確認
+        assertTrue(spans[0].events.any { it.name == "exception" })
+    }
+
+    @Test
+    @DisplayName("withDatabaseSpan sets db attributes and span name")
+    fun withDatabaseSpanSetsDbAttributesAndSpanName() = runBlocking {
+        // TelemetryProviderが未初期化のためNoOp Tracerになるが、例外なく実行できることを確認
+        val result = withDatabaseSpan("oauth_clients", "select") { 42 }
+        assertEquals(42, result)
+    }
+}

--- a/docs/content/docs/administrator/config/observability.mdx
+++ b/docs/content/docs/administrator/config/observability.mdx
@@ -20,8 +20,11 @@ MineAuth supports observability features including distributed tracing with Open
       }
     ],
     "serviceName": "mineauth",
+    "serviceNamespace": "minecraft",
     "metricsEnabled": true,
-    "healthEnabled": true
+    "healthEnabled": true,
+    "otlpMetricsEnabled": true,
+    "metricExportIntervalSeconds": 60
   }
 }
 ```
@@ -33,8 +36,11 @@ MineAuth supports observability features including distributed tracing with Open
 | `enabled` | boolean | `false` | Enable OpenTelemetry tracing |
 | `exporters` | array | `[{"protocol": "GRPC", "endpoint": "http://localhost:4317", "headers": {}}]` | List of OTLP exporter configurations |
 | `serviceName` | string | `mineauth` | Service name displayed in traces |
+| `serviceNamespace` | string | `minecraft` | `service.namespace` resource attribute (logical group name for multi-server setups) |
 | `metricsEnabled` | boolean | `true` | Enable `/metrics` endpoint (Prometheus format) |
 | `healthEnabled` | boolean | `true` | Enable `/health` endpoint |
+| `otlpMetricsEnabled` | boolean | `true` | Export metrics via OTLP (only when `enabled` is `true`) |
+| `metricExportIntervalSeconds` | number | `60` | Interval for periodic OTLP metric export |
 
 ### Exporter Configuration
 
@@ -79,11 +85,65 @@ curl http://localhost:8080/metrics
 This endpoint provides:
 - HTTP request counts and latencies
 - JVM metrics (memory, threads, GC)
-- Custom application metrics
+- Minecraft server metrics (see below)
+
+### Minecraft Server Metrics
+
+The following gauges are collected from the Paper server. They are available both at the `/metrics` endpoint (Prometheus naming, e.g. `minecraft_players_online`) and via OTLP metric export:
+
+| Metric | Tags | Description |
+|--------|------|-------------|
+| `minecraft.players.online` | — | Number of online players |
+| `minecraft.players.max` | — | Maximum number of players |
+| `minecraft.server.tps` | `window` = `1m` / `5m` / `15m` | Server ticks per second (moving averages) |
+| `minecraft.server.tick.duration.average` | — | Average tick duration in milliseconds (MSPT) |
+| `minecraft.worlds.count` | — | Number of loaded worlds |
+| `minecraft.entities.count` | `world` | Number of entities per world |
+| `minecraft.chunks.loaded` | `world` | Number of loaded chunks per world |
+
+Note: per-world gauges are registered for the worlds that exist when the web server starts. Worlds loaded afterwards are picked up after a `/mineauth reload`.
+
+### OTLP Metric Export
+
+When both `enabled` and `otlpMetricsEnabled` are `true`, all metrics (HTTP, JVM, and Minecraft gauges) are also exported via OTLP to the same `exporters` list used for traces, every `metricExportIntervalSeconds` seconds.
+
+- `GRPC` exporters use port `4317`
+- `HTTP` exporters use port `4318`; the SDK appends `/v1/metrics` automatically
 
 ## OpenTelemetry Tracing
 
 When `enabled` is `true`, MineAuth sends distributed traces to the configured OTLP endpoints.
+
+### Resource Attributes
+
+Every trace and metric is annotated with the following resource attributes, which help identify the source when multiple servers report to the same backend:
+
+| Attribute | Source |
+|-----------|--------|
+| `service.name` | `serviceName` configuration |
+| `service.namespace` | `serviceNamespace` configuration |
+| `service.version` | MineAuth plugin version |
+| `host.name` | Server host name |
+| `minecraft.version` | Minecraft version (e.g. `1.21.11`) |
+| `minecraft.server.brand` | Server implementation (e.g. `Paper`) |
+| `minecraft.plugin.name` | Plugin name |
+
+### Spans
+
+In addition to the automatic HTTP server spans, MineAuth records manual spans for the interesting parts of each request, including:
+
+- OAuth flows: `oauth.token`, `oauth.client.authenticate`, `oauth.user.authenticate`, `oauth.refresh_token.verify`, `oauth.refresh_token.rotate`, `oauth.introspect`, `oauth.revoke`
+- JWT operations: `jwt.issue` (with `mineauth.token.type` = `access` / `refresh` / `id`), `jwt.validate.user_token`, `jwt.validate.service_token`
+- Database access: `db.<table>.<operation>` (e.g. `db.oauth_clients.select`)
+- Addon routes: `mineauth.plugin.handler`
+
+See the contributor documentation for the full span and attribute catalog.
+
+### Privacy Policy for Telemetry Data
+
+- Span names never contain identifiers; UUID values in span names are automatically masked as an additional safeguard
+- Player UUIDs may appear as the `mineauth.player.uuid` span attribute (pseudonymous identifier, required for correlation)
+- Usernames, passwords, client secrets, tokens, authorization codes, and PKCE verifiers are never recorded
 
 ### Supported Backends
 

--- a/docs/content/docs/contributer/meta.json
+++ b/docs/content/docs/contributer/meta.json
@@ -2,5 +2,5 @@
 	"title": "Contributer",
 	"icon": "Users",
 	"root": true,
-	"pages": ["endpoint", "reference", "record"]
+	"pages": ["endpoint", "reference", "telemetry", "record"]
 }

--- a/docs/content/docs/contributer/telemetry.mdx
+++ b/docs/content/docs/contributer/telemetry.mdx
@@ -1,0 +1,76 @@
+---
+title: Telemetry
+description: Span catalog and how to add instrumentation with withSpan / withDatabaseSpan
+---
+
+MineAuth uses OpenTelemetry for distributed tracing and metrics. This page describes the telemetry produced by the core plugin and how to add instrumentation to new code.
+
+## Architecture
+
+- `TelemetryProvider` (`core/.../web/telemetry/TelemetryProvider.kt`) bootstraps the OpenTelemetry SDK: tracer provider, meter provider, OTLP exporters, and resource attributes. When observability is disabled it returns a no-op implementation, so instrumentation helpers are always safe to call.
+- `KtorServerTelemetry` automatically creates one HTTP server span per inbound request. Manual spans created inside request handlers become children of that server span.
+- Micrometer metrics are registered once on a `CompositeMeterRegistry` that fans out to the Prometheus registry (`/metrics`) and, when enabled, to the OpenTelemetry bridge (OTLP export).
+
+## Span Catalog
+
+| Span name | Location | Attributes |
+|-----------|----------|------------|
+| `oauth.token` | `TokenRouter` | `mineauth.oauth.grant_type`, `mineauth.client.id`, `mineauth.oauth.scope`, `mineauth.player.uuid` |
+| `oauth.client.authenticate` | `TokenRouter`, `IntrospectRouter`, `RevokeRouter` | `mineauth.client.id` |
+| `oauth.user.authenticate` | `AuthorizeRouter` | `mineauth.auth.result` |
+| `oauth.refresh_token.verify` | `TokenRouter` | — |
+| `oauth.refresh_token.rotate` | `TokenRouter` | — |
+| `oauth.introspect` | `IntrospectRouter` | `mineauth.auth.result` (`active` / `inactive`) |
+| `oauth.revoke` | `RevokeRouter` | `mineauth.client.id`, `mineauth.token.type_hint` |
+| `jwt.issue` | `TokenRouter` | `mineauth.token.type` (`access` / `refresh` / `id`) |
+| `jwt.validate.user_token` | `WebServer` (JWT validation) | `mineauth.client.id`, `mineauth.auth.result` |
+| `jwt.validate.service_token` | `WebServer` (JWT validation) | `mineauth.auth.result` |
+| `db.<table>.<operation>` | Repositories, `OAuthService` | `db.system.name`, `db.collection.name`, `db.operation.name` |
+| `mineauth.plugin.handler` | `RouteExecutor` (all addon routes) | `mineauth.handler.class`, `mineauth.endpoint.path`, `mineauth.endpoint.method` |
+
+In addition, `respondOAuthError` records `mineauth.oauth.error_code` and sets the span status to `ERROR` on the current span for every OAuth error response.
+
+All attribute keys are defined in `TelemetryAttributes` (`core/.../web/telemetry/TelemetryAttributes.kt`).
+
+## Adding Instrumentation
+
+Use the helpers in `TracingSupport.kt` instead of the raw OpenTelemetry API.
+
+### withSpan
+
+```kotlin
+val result = withSpan("oauth.example", attributes = Attributes.of(TelemetryAttributes.CLIENT_ID, clientId)) { span ->
+    // The span is active in the coroutine context here,
+    // so nested withSpan calls become children automatically.
+    span.setAttribute(TelemetryAttributes.AUTH_RESULT, "valid")
+    doSomething()
+}
+```
+
+- The current OpenTelemetry context is used as the parent, so spans created inside a Ktor handler nest under the HTTP server span.
+- Exceptions are recorded on the span and the status is set to `ERROR` before being rethrown.
+- When tracing is disabled the tracer is a no-op, so there is no overhead concern in calling it unconditionally.
+
+### withDatabaseSpan
+
+```kotlin
+suspend fun findById(id: String): Either<Error, Data> =
+    withDatabaseSpan("oauth_clients", "select") {
+        newSuspendedTransaction {
+            // Exposed query
+        }
+    }
+```
+
+This produces a `CLIENT` span named `db.<table>.<operation>` with semconv-style database attributes.
+
+## Rules for Telemetry Data
+
+- Never put identifiers in span names — use attributes instead. `SanitizingSpanProcessor` masks UUID-shaped values in span names as a safety net.
+- Player UUIDs are allowed as the `mineauth.player.uuid` attribute.
+- Never record usernames, passwords, client secrets, tokens, authorization codes, or PKCE verifiers — neither in names, attributes, nor events.
+- Prefer low-cardinality attribute values (result labels, grant types) so metrics and trace search stay usable.
+
+## Adding Metrics
+
+Register Micrometer meters on the registry passed to `MinecraftMetrics`-style binders in `WebServer.module()`. Anything registered on the composite registry automatically appears both at `/metrics` and in OTLP export. Use observable gauges (pull-based) where possible and only read values that are safe to access off the main server thread.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,9 @@ opentelemetry-sdk = { group = "io.opentelemetry", name = "opentelemetry-sdk", ve
 opentelemetry-exporter-otlp = { group = "io.opentelemetry", name = "opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
 opentelemetry-semconv = { group = "io.opentelemetry.semconv", name = "opentelemetry-semconv", version = "1.42.0" }
 opentelemetry-ktor = { group = "io.opentelemetry.instrumentation", name = "opentelemetry-ktor-3.0", version.ref = "opentelemetry-instrumentation" }
+opentelemetry-extension-kotlin = { group = "io.opentelemetry", name = "opentelemetry-extension-kotlin", version.ref = "opentelemetry" }
+opentelemetry-micrometer = { group = "io.opentelemetry.instrumentation", name = "opentelemetry-micrometer-1.5", version.ref = "opentelemetry-instrumentation" }
+opentelemetry-sdk-testing = { group = "io.opentelemetry", name = "opentelemetry-sdk-testing", version.ref = "opentelemetry" }
 
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-java = { group = "io.ktor", name = "ktor-client-java", version.ref = "ktor" }
@@ -111,7 +114,7 @@ maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPubli
 
 [bundles]
 commands = ["cloud", "cloudPaper", "cloud-annotations", "cloud-kotlin-coroutines-annotations"]
-opentelemetry = ["opentelemetry-api", "opentelemetry-sdk", "opentelemetry-exporter-otlp", "opentelemetry-semconv", "opentelemetry-ktor"]
+opentelemetry = ["opentelemetry-api", "opentelemetry-sdk", "opentelemetry-exporter-otlp", "opentelemetry-semconv", "opentelemetry-ktor", "opentelemetry-extension-kotlin", "opentelemetry-micrometer"]
 securities = ["password4j", "nimbus-jose-jwt", "bcpkix-jdk18on"]
 coroutines = ["mccoroutine-bukkit-api", "mccoroutine-bukkit-core" , "kotlinx-coroutines-core"]
 exposed = ["exposed-core", "exposed-dao", "exposed-jdbc", "exposed-java-time"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ mysql = "9.7.0"
 micrometer = "1.17.0"
 opentelemetry = "1.63.0"
 opentelemetry-instrumentation = "2.30.0-alpha-SNAPSHOT"
+allure = "2.35.3"
 
 
 [libraries]
@@ -64,6 +65,8 @@ opentelemetry-ktor = { group = "io.opentelemetry.instrumentation", name = "opent
 opentelemetry-extension-kotlin = { group = "io.opentelemetry", name = "opentelemetry-extension-kotlin", version.ref = "opentelemetry" }
 opentelemetry-micrometer = { group = "io.opentelemetry.instrumentation", name = "opentelemetry-micrometer-1.5", version.ref = "opentelemetry-instrumentation" }
 opentelemetry-sdk-testing = { group = "io.opentelemetry", name = "opentelemetry-sdk-testing", version.ref = "opentelemetry" }
+
+allure-junit5 = { group = "io.qameta.allure", name = "allure-junit5", version.ref = "allure" }
 
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-java = { group = "io.ktor", name = "ktor-client-java", version.ref = "ktor" }


### PR DESCRIPTION
## Summary
- Add manual spans (`withSpan`/`withDatabaseSpan` helpers) across OAuth/OIDC flows, JWT validation, and DB access, so OTLP shows the internal request flow instead of just the bare HTTP span
- Enrich resource attributes with `service.version`, `service.namespace`, `host.name`, and Minecraft/Paper server info
- Export metrics via OTLP (`SdkMeterProvider` + `PeriodicMetricReader`) alongside the existing Prometheus `/metrics` endpoint (Micrometer → OTel bridge on a shared `CompositeMeterRegistry`)
- Add Minecraft server gauges: online/max players, TPS (1m/5m/15m), MSPT, worlds, per-world entity/chunk counts
- New config: `otlpMetricsEnabled`, `metricExportIntervalSeconds`, `serviceNamespace` (all backward-compatible defaults)
- PII policy: span names never contain identifiers; player UUIDs allowed as attributes; usernames/passwords/secrets/tokens never recorded
- Docs updated: `administrator/config/observability.mdx` and new `contributer/telemetry.mdx` span catalog

### CI: Allure report + direct attestation links
Mirrored from `MoripaFishing`'s `preview.yml`/`upload.yml`:
- Add `allure-junit5` test dependency and `allure.results.directory` system property so JUnit runs emit Allure results
- `preview.yml` installs the Allure CLI, aggregates per-module results, generates a report, uploads it to S3, and links it in the PR preview comment alongside JUnit/Detekt
- `preview.yml` and `upload.yml` now capture the `attestation-url` output from `attest-build-provenance` and surface a direct "View attestation" link (in addition to the existing `gh attestation verify` instructions) in preview comments and release notes

## Test plan
- [x] `task build` (gradle clean build incl. tests) passes for all new/changed tests
- [x] Verified `WebServerIntegrationTest` / `AnnotationProcessorTest` failures are pre-existing on `master` (MockBukkit/paper-api version mismatch), unrelated to this change
- [x] Confirmed new OTel classes (extension-kotlin, micrometer bridge) are bundled in shadowJar
- [x] Confirmed `core/build/allure-results/*.json` are generated locally after `./gradlew :core:test`
- [x] Validated `preview.yml`/`upload.yml` YAML syntax
- [ ] Manual E2E against an OTLP collector (e.g. `grafana/otel-lgtm`) to visually confirm span nesting and metric arrival
- [ ] Confirm Allure report renders and attestation links resolve once this PR's `preview.yml` run completes