### PR TITLE
🐛 Fix SerializationException for List-returning RegisterHandler endpoints

### DIFF
--- a/core/src/main/kotlin/party/morino/mineauth/core/plugin/route/RouteExecutor.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/plugin/route/RouteExecutor.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
+import io.ktor.util.reflect.TypeInfo
 import io.opentelemetry.api.common.Attributes
 import kotlinx.serialization.json.JsonPrimitive
 import org.koin.core.component.KoinComponent
@@ -13,7 +14,9 @@ import party.morino.mineauth.core.plugin.execution.ExecutionError
 import party.morino.mineauth.core.plugin.execution.MethodExecutionHandlerFactory
 import party.morino.mineauth.core.web.telemetry.TelemetryAttributes
 import party.morino.mineauth.core.web.telemetry.withSpan
+import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
+import kotlin.reflect.jvm.javaType
 
 /**
  * ハンドラーメソッドを実行するクラス
@@ -55,7 +58,7 @@ class RouteExecutor(
             // ハンドラーを実行して結果を処理
             when (val result = handler.execute(metadata, resolvedParams)) {
                 is Either.Left -> handleExecutionError(call, result.value, metadata, resolvedParams)
-                is Either.Right -> handleResult(call, result.value)
+                is Either.Right -> handleResult(call, result.value, metadata)
             }
         }
     }
@@ -116,15 +119,32 @@ class RouteExecutor(
     /**
      * メソッドの戻り値をHTTPレスポンスに変換する
      *
+     * リフレクション経由の呼び出しでは戻り値の静的型情報（ジェネリクス含む）が失われ、
+     * Ktorの`guessSerializer`によるリスト要素の型推測が外部プラグインのクラスに対して失敗するため、
+     * ハンドラーの宣言上の戻り値型（`KType`）から`TypeInfo`を構築して`respond`に明示的に渡す。
+     *
      * @param call ApplicationCall
      * @param result メソッドの戻り値
+     * @param metadata エンドポイントメタデータ（宣言上の戻り値型を取得するために使用）
      */
-    private suspend fun handleResult(call: ApplicationCall, result: Any?) {
+    private suspend fun handleResult(call: ApplicationCall, result: Any?, metadata: EndpointMetadata) {
         when (result) {
             null -> call.respond(HttpStatusCode.NoContent)
             is Unit -> call.respond(HttpStatusCode.OK)
-            else -> call.respond(result)
+            else -> call.respond(result, resolveTypeInfo(metadata))
         }
+    }
+
+    /**
+     * ハンドラーメソッドの宣言上の戻り値型から`TypeInfo`を構築する
+     *
+     * @param metadata エンドポイントメタデータ
+     * @return 戻り値型に基づく`TypeInfo`
+     */
+    private fun resolveTypeInfo(metadata: EndpointMetadata): TypeInfo {
+        val returnType = metadata.method.returnType
+        val classifier = returnType.classifier as? KClass<*> ?: Any::class
+        return TypeInfo(classifier, returnType.javaType, returnType)
     }
 
     /**

--- a/docs/content/docs/developer/addons/register-handler.mdx
+++ b/docs/content/docs/developer/addons/register-handler.mdx
@@ -222,6 +222,10 @@ suspend fun getShop(@PathParam("id") id: String): ShopData {
 }
 ```
 
+## Notes on List Responses
+
+Handler methods may return `List<T>` of any `@Serializable` data class, including classes defined in the calling plugin. MineAuth resolves the handler's declared return type when serializing the response, so list element types are serialized correctly without relying on runtime type guessing.
+
 ## Method Chaining
 
 `register()` returns the `RegisterHandler` instance, allowing method chaining:


### PR DESCRIPTION
## Summary
- `RouteExecutor.handleResult` now builds a Ktor `TypeInfo` from the handler's declared return `KType` (`metadata.method.returnType`) and passes it to `call.respond(result, typeInfo)`.
- Previously, reflection-based handler dispatch lost static return type information, so `call.respond(result)` fell through to Ktor's `guessSerializer` reflection fallback, which fails to resolve serializers for external plugins' `@Serializable` list element classes.
- Fixes #369 (reported via mpm plugin: `GET /api/v1/plugins/mpm/plugins` returning `List<PluginSummaryResponse>` threw `SerializationException`).

## Test plan
- [x] `task build` — compiles successfully
- [x] Confirmed the 2 pre-existing test failures (`WebServerIntegrationTest`, `AnnotationProcessorTest`) also fail on `master` without this change (MockBukkit/Minecraft registry version mismatch, unrelated to this fix)
- [ ] Manual verification against mpm's `/plugins` endpoint recommended before release