### PR TITLE
fix(telemetry): stop stripping /v1/traces and /v1/metrics from HTTP OTLP endpoints

### DIFF
--- a/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/TelemetryProvider.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/TelemetryProvider.kt
@@ -86,9 +86,12 @@ object TelemetryProvider : KoinComponent {
             }
             plugin.logger.info("Initializing OpenTelemetry ${exporter.protocol} exporter for: $endpointHost")
 
-            // HTTPプロトコルで/v1/tracesが含まれている場合は警告
-            if (exporter.protocol == OtlpExporterProtocol.HTTP && exporter.endpoint.contains("/v1/traces")) {
-                plugin.logger.warning("HTTP endpoint contains '/v1/traces' suffix - this will be automatically removed (SDK appends it)")
+            // HTTPプロトコルではSDKがパスを自動付与しないため、シグナル別のフルパスを含める必要がある
+            if (exporter.protocol == OtlpExporterProtocol.HTTP &&
+                !exporter.endpoint.contains("/v1/traces") &&
+                !exporter.endpoint.contains("/v1/metrics")
+            ) {
+                plugin.logger.warning("HTTP endpoint does not include a signal path (e.g. '/v1/traces') - the SDK does not append it automatically, exports will likely 404")
             }
         }
 
@@ -237,11 +240,9 @@ object TelemetryProvider : KoinComponent {
             }
             OtlpExporterProtocol.HTTP -> {
                 // HTTPエクスポーターを構築
-                // 注意: OtlpHttpSpanExporterは自動的に/v1/tracesを追加する
-                // ユーザーが誤って/v1/tracesを含めた場合は除去する
-                val normalizedEndpoint = config.endpoint
-                    .removeSuffix("/v1/traces")
-                    .removeSuffix("/")
+                // 注意: OtlpHttpSpanExporterはパスを自動付与しないため、
+                // config.endpointにシグナル別のフルパス（例: /v1/traces）を含める必要がある
+                val normalizedEndpoint = config.endpoint.removeSuffix("/")
 
                 val builder = OtlpHttpSpanExporter.builder()
                     .setEndpoint(normalizedEndpoint)
@@ -282,12 +283,9 @@ object TelemetryProvider : KoinComponent {
             }
             OtlpExporterProtocol.HTTP -> {
                 // HTTPエクスポーターを構築
-                // 注意: OtlpHttpMetricExporterは自動的に/v1/metricsを追加する
-                // ユーザーが誤ってシグナル別のパスを含めた場合は除去する
-                val normalizedEndpoint = config.endpoint
-                    .removeSuffix("/v1/metrics")
-                    .removeSuffix("/v1/traces")
-                    .removeSuffix("/")
+                // 注意: OtlpHttpMetricExporterはパスを自動付与しないため、
+                // config.endpointにシグナル別のフルパス（例: /v1/metrics）を含める必要がある
+                val normalizedEndpoint = config.endpoint.removeSuffix("/")
 
                 val builder = OtlpHttpMetricExporter.builder()
                     .setEndpoint(normalizedEndpoint)

--- a/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/TelemetryProviderTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/TelemetryProviderTest.kt
@@ -44,9 +44,10 @@ class TelemetryProviderTest {
     }
 
     @Test
-    @DisplayName("HTTP endpoint with signal path suffix is normalized")
-    fun httpEndpointWithSignalPathSuffixIsNormalized() {
-        // ユーザーが誤って/v1/metricsを含めた場合でも二重に付与されないことを確認
+    @DisplayName("HTTP endpoint with signal path is passed through unmodified")
+    fun httpEndpointWithSignalPathIsPassedThroughUnmodified() {
+        // OtlpHttpMetricExporterはパスを自動付与しないため、/v1/metricsを含むフルパスが
+        // そのままエンドポイントとして使われる（削られたり二重に付与されたりしない）ことを確認
         val config = OtlpExporterConfig(
             protocol = OtlpExporterProtocol.HTTP,
             endpoint = "http://localhost:4318/v1/metrics"
@@ -54,7 +55,7 @@ class TelemetryProviderTest {
 
         val exporter = TelemetryProvider.createMetricExporter(config)
 
-        // SDKが/v1/metricsを自動付与するため、二重付与になっていないことを確認
+        assertTrue(exporter.toString().contains("localhost:4318/v1/metrics"))
         assertFalse(exporter.toString().contains("/v1/metrics/v1/metrics"))
         exporter.shutdown()
     }

--- a/docs/content/docs/administrator/config/observability.mdx
+++ b/docs/content/docs/administrator/config/observability.mdx
@@ -55,7 +55,7 @@ Each exporter in the `exporters` array supports:
 #### Protocol Notes
 
 - `GRPC` uses port `4317` and no path (e.g., `https://otlp-gateway...:4317`)
-- `HTTP` uses port `4318` with `/otlp/v1/traces` (e.g., `https://otlp-gateway...:4318/otlp/v1/traces`)
+- `HTTP` uses port `4318` and the SDK does **not** append a path automatically — `endpoint` must include the full signal-specific path: `/v1/traces` for traces (e.g., `https://otlp-gateway...:4318/v1/traces`) and `/v1/metrics` for metrics (e.g., `https://otlp-gateway...:4318/v1/metrics`)
 
 ## Endpoints
 
@@ -108,7 +108,7 @@ Note: per-world gauges are registered for the worlds that exist when the web ser
 When both `enabled` and `otlpMetricsEnabled` are `true`, all metrics (HTTP, JVM, and Minecraft gauges) are also exported via OTLP to the same `exporters` list used for traces, every `metricExportIntervalSeconds` seconds.
 
 - `GRPC` exporters use port `4317`
-- `HTTP` exporters use port `4318`; the SDK appends `/v1/metrics` automatically
+- `HTTP` exporters use port `4318`; `endpoint` must include the `/v1/metrics` path explicitly (the SDK does not append it). Note that the same `exporters` list is reused for both traces and metrics, so an `HTTP` endpoint ending in `/v1/traces` will not work for metric export — use `GRPC`, or a separate exporter entry, if you need both signals over HTTP.
 
 ## OpenTelemetry Tracing
 


### PR DESCRIPTION
## Summary

Fixes #372.

`OtlpHttpSpanExporter` / `OtlpHttpMetricExporter` require the full signal path in `setEndpoint()` (e.g. `https://host:4318/v1/traces`) and never append it automatically — see the `opentelemetry-java` SDK javadoc: "the endpoint must start with either http:// or https://, and include the full HTTP path."

`TelemetryProvider` was doing the opposite: unconditionally stripping any `/v1/traces` / `/v1/metrics` suffix from the configured endpoint before handing it to the builder, under the (incorrect) assumption that the SDK appends it. Every `HTTP`-protocol exporter therefore sent requests to the endpoint root and got 404'd by the receiver.

## Changes

- Removed the incorrect `removeSuffix("/v1/traces")` / `removeSuffix("/v1/metrics")` calls in `createSpanExporter` and `createMetricExporter`; `config.endpoint` is now passed through as-is (only a trailing `/` is trimmed).
- Corrected the startup warning log to flag endpoints that are *missing* a signal path, instead of warning about the (correct) presence of one.
- Updated `observability.mdx` to state that `HTTP` protocol requires the full signal path in `endpoint`, and to note that a single `HTTP` exporter entry can't serve both traces and metrics (see issue for follow-up).
- Updated `TelemetryProviderTest` — the existing test asserted the old (wrong) behavior in its comments; now verifies the endpoint is passed through unmodified.

## Test plan

- [x] `./gradlew :core:test --tests "party.morino.mineauth.core.web.telemetry.TelemetryProviderTest"` — 3/3 passing
- [x] Manually verified against a real Jaeger OTLP HTTP receiver behind an ingress: with `endpoint: "https://.../v1/traces"` traces now export successfully (previously 404'd regardless of config)