### PR TITLE
🔭 Strip authenticate selector from OTel http.route and enrich plugin spans

### DIFF
--- a/core/src/main/kotlin/party/morino/mineauth/core/plugin/dispatch/PluginEndpointDispatcher.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/plugin/dispatch/PluginEndpointDispatcher.kt
@@ -5,7 +5,12 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.context.Context
+import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute
+import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource
 import org.koin.core.component.KoinComponent
+import party.morino.mineauth.api.auth.Principal
 import party.morino.mineauth.core.plugin.annotation.EndpointAccess
 import party.morino.mineauth.core.plugin.annotation.EndpointMetadata
 import party.morino.mineauth.core.plugin.annotation.HttpMethodType
@@ -14,6 +19,7 @@ import party.morino.mineauth.core.plugin.route.AuthenticationHandler
 import party.morino.mineauth.core.plugin.route.ErrorResponse
 import party.morino.mineauth.core.plugin.route.RequestContext
 import party.morino.mineauth.core.plugin.route.RouteExecutor
+import party.morino.mineauth.core.web.telemetry.TelemetryAttributes
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -79,7 +85,11 @@ class PluginEndpointDispatcher(
     suspend fun dispatch(call: ApplicationCall) {
         // 名前空間のテーブルを取得（未登録の名前空間は404）
         val namespace = call.parameters["namespace"]
-        val table = namespace?.let { tables[it] }
+        if (namespace == null) {
+            respondNotFound(call)
+            return
+        }
+        val table = tables[namespace]
         if (table == null) {
             respondNotFound(call)
             return
@@ -125,6 +135,27 @@ class PluginEndpointDispatcher(
         // 例: /shops/mine と /shops/{id} が両方マッチしたら /shops/mine を選ぶ
         val (endpoint, pathParams) = methodMatches.maxByOrNull { specificity(it.first.pathSegments) }!!
 
+        // OpenTelemetryのhttp.route（サーバースパン名）を実エンドポイントのテンプレートに補正する。
+        // Ktorのルートは単一のキャッチオール（/api/v1/plugins/{namespace}/{path...}）のため、
+        // ディスパッチャがマッチさせた実際のテンプレート（例: /api/v1/plugins/vault/shops/{id}）に
+        // 上書きすることで、エンドポイント単位で識別・集計できるようにする。
+        // NESTED_CONTROLLER(order=4)はサニタイザのCONTROLLER(order=3)より優先度が高いため、
+        // ルート文字列の長短に関わらず必ずこの値が採用される。
+        val routeTemplate = table.basePath + endpoint.path
+        HttpServerRoute.update(
+            Context.current(),
+            HttpServerRouteSource.NESTED_CONTROLLER,
+            routeTemplate
+        )
+        // サーバースパンにプラグイン・ルートの識別属性を付与する（トップレベルHTTPスパンを検索可能にする）
+        // トレーシング無効時はSpan.current()がNoOpとなり、setAttributeは安全に無視される
+        Span.current().apply {
+            setAttribute(TelemetryAttributes.PLUGIN_NAMESPACE, namespace)
+            setAttribute(TelemetryAttributes.PLUGIN_OWNER, table.pluginName)
+            setAttribute(TelemetryAttributes.ROUTE_TEMPLATE, routeTemplate)
+            setAttribute(TelemetryAttributes.ENDPOINT_ACCESS, accessLabel(endpoint.access))
+        }
+
         // 認証・認可（失敗時はレスポンス済みで終了）
         val principal = when (val access = endpoint.access) {
             is EndpointAccess.Public -> when (val result = authHandler.optionalPrincipal(call)) {
@@ -144,8 +175,34 @@ class PluginEndpointDispatcher(
             }
         }
 
+        // 認証結果が確定したので、呼び出し元の種別をサーバースパンに記録する
+        Span.current().setAttribute(TelemetryAttributes.CALLER_TYPE, callerTypeLabel(principal))
+
         // ハンドラーを実行
         executor.execute(RequestContext(call, principal, pathParams), endpoint)
+    }
+
+    /**
+     * アクセス区分を属性値の文字列に変換する
+     *
+     * @param access エンドポイントのアクセス制御設定
+     * @return "public" もしくは "authenticated"
+     */
+    private fun accessLabel(access: EndpointAccess): String = when (access) {
+        is EndpointAccess.Public -> "public"
+        is EndpointAccess.Authenticated -> "authenticated"
+    }
+
+    /**
+     * 認証済みPrincipalを呼び出し元種別の文字列に変換する
+     *
+     * @param principal 認証済みPrincipal（公開エンドポイントで未認証の場合null）
+     * @return "user" / "service" / "anonymous"
+     */
+    private fun callerTypeLabel(principal: Principal?): String = when (principal) {
+        is Principal.User -> "user"
+        is Principal.Service -> "service"
+        null -> "anonymous"
     }
 
     /**

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/WebServer.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/WebServer.kt
@@ -47,6 +47,7 @@ import party.morino.mineauth.core.plugin.dispatch.PluginEndpointDispatcher
 import party.morino.mineauth.core.web.telemetry.MinecraftMetrics
 import party.morino.mineauth.core.web.telemetry.TelemetryAttributes
 import party.morino.mineauth.core.web.telemetry.TelemetryProvider
+import party.morino.mineauth.core.web.telemetry.installAuthRouteSanitizer
 import party.morino.mineauth.core.web.telemetry.withSpan
 import java.security.KeyStore
 import java.util.concurrent.TimeUnit
@@ -102,6 +103,9 @@ internal fun Application.module() {
         install(KtorServerTelemetry) {
             setOpenTelemetry(openTelemetry)
         }
+        // KtorServerTelemetryが設定するhttp.routeから認証セレクタ由来のノイズ
+        // （例: "(authenticate user-oauth-token, service-oauth-token)"）を除去する
+        installAuthRouteSanitizer()
     }
 
     // Prometheusメトリクスレジストリ（/metricsエンドポイント用）

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/HttpRouteSupport.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/HttpRouteSupport.kt
@@ -1,0 +1,69 @@
+package party.morino.mineauth.core.web.telemetry
+
+import io.ktor.server.application.Application
+import io.ktor.server.routing.RoutingNode
+import io.ktor.server.routing.RoutingRoot
+import io.opentelemetry.context.Context
+import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute
+import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource
+
+/**
+ * OpenTelemetryの`http.route`（HTTPサーバースパン名）を補正するためのヘルパー
+ *
+ * 背景:
+ * KtorServerTelemetryは`RoutingRoot.RoutingCallStarted`で
+ * `matchedRoute.parent.toString()`を`http.route`として設定する。
+ * このルート文字列は`authenticate { ... }`で包まれたルートの場合、
+ * 認証セレクタの文字列（例: `(authenticate user-oauth-token, service-oauth-token)`）を
+ * そのまま含んでしまい、スパン名が
+ * `/(authenticate user-oauth-token, service-oauth-token)/api/v1/plugins/{namespace}`
+ * のように汚染される。
+ *
+ * ここでは認証セレクタ由来のセグメントを除去し、素直なルートテンプレートに戻す。
+ */
+
+// 認証ルートセレクタの`toString()`形式（例: "(authenticate user-oauth-token, service-oauth-token)"）
+// プロバイダ名にスラッシュは含まれないため、1つのパスセグメント全体がこの形にマッチする
+private val AUTHENTICATE_SELECTOR = Regex("""\(authenticate .*\)""")
+
+/**
+ * ルート文字列から認証セレクタ由来のセグメントを取り除く
+ *
+ * 例: `/(authenticate user-oauth-token, service-oauth-token)/api/v1/plugins/{namespace}`
+ *   → `/api/v1/plugins/{namespace}`
+ *
+ * Ktor本体が生成したルート文字列をそのまま入力に取り、既知の汚染セグメントのみを
+ * 外科的に除去することで、Ktorのルート表記そのものは維持する。
+ *
+ * @param route Ktorが生成したルート文字列
+ * @return 認証セレクタを除去したルート文字列
+ */
+fun sanitizeAuthRoute(route: String): String =
+    route.split("/")
+        .filterNot { AUTHENTICATE_SELECTOR.matches(it) }
+        .joinToString("/")
+
+/**
+ * すべてのルートに対して`http.route`から認証セレクタを除去するサニタイザを登録する
+ *
+ * KtorServerTelemetryと同じ`RoutingRoot.RoutingCallStarted`を購読し、
+ * より優先度の高いソース（CONTROLLER）でルートを上書きする。
+ * `CONTROLLER`(order=3)はライブラリが使う`SERVER`(order=2)より優先度が高いため、
+ * 購読の実行順序に関わらず必ずこちらの値が採用される。
+ *
+ * トレーシングが無効の場合、Context上にHttpRouteStateが存在しないため
+ * `HttpServerRoute.update`は安全にno-opとなる。
+ *
+ * @receiver 対象のKtor Application
+ */
+fun Application.installAuthRouteSanitizer() {
+    monitor.subscribe(RoutingRoot.RoutingCallStarted) { call ->
+        // マッチしたルートの親（メソッドセレクタを除いた部分）を起点にサニタイズする
+        val parent: RoutingNode = call.route.parent ?: return@subscribe
+        HttpServerRoute.update(
+            Context.current(),
+            HttpServerRouteSource.CONTROLLER,
+            sanitizeAuthRoute(parent.toString())
+        )
+    }
+}

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/TelemetryAttributes.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/TelemetryAttributes.kt
@@ -63,6 +63,22 @@ object TelemetryAttributes {
     // アドオンルートのHTTPメソッド
     val ENDPOINT_METHOD: AttributeKey<String> = AttributeKey.stringKey("mineauth.endpoint.method")
 
+    // アドオンエンドポイントのURL名前空間（例: vault）
+    val PLUGIN_NAMESPACE: AttributeKey<String> = AttributeKey.stringKey("mineauth.plugin.namespace")
+
+    // 名前空間を所有するプラグイン名（登録元アドオン）
+    val PLUGIN_OWNER: AttributeKey<String> = AttributeKey.stringKey("mineauth.plugin.owner")
+
+    // マッチしたエンドポイントのルートテンプレート（例: /api/v1/plugins/vault/shops/{id}）
+    // 具体的なID値ではなくテンプレートを記録するため、カーディナリティが低くPIIも含まない
+    val ROUTE_TEMPLATE: AttributeKey<String> = AttributeKey.stringKey("mineauth.route.template")
+
+    // エンドポイントのアクセス区分（public / authenticated）
+    val ENDPOINT_ACCESS: AttributeKey<String> = AttributeKey.stringKey("mineauth.endpoint.access")
+
+    // 呼び出し元の種別（user / service / anonymous）
+    val CALLER_TYPE: AttributeKey<String> = AttributeKey.stringKey("mineauth.auth.caller_type")
+
     // トークン種別ヒント（introspect / revokeのtoken_type_hint）
     val TOKEN_TYPE_HINT: AttributeKey<String> = AttributeKey.stringKey("mineauth.token.type_hint")
 

--- a/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/HttpRouteSpanNameTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/HttpRouteSpanNameTest.kt
@@ -1,0 +1,198 @@
+package party.morino.mineauth.core.web.telemetry
+
+import arrow.core.Either
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.install
+import io.ktor.server.auth.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.testApplication
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.instrumentation.ktor.v3_0.KtorServerTelemetry
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import party.morino.mineauth.core.plugin.annotation.EndpointAccess
+import party.morino.mineauth.core.plugin.annotation.EndpointMetadata
+import party.morino.mineauth.core.plugin.annotation.HttpMethodType
+import party.morino.mineauth.core.plugin.annotation.PathSegment
+import party.morino.mineauth.core.plugin.dispatch.NamespaceTable
+import party.morino.mineauth.core.plugin.dispatch.PluginEndpointDispatcher
+import party.morino.mineauth.core.plugin.execution.ExecutionError
+import party.morino.mineauth.core.plugin.execution.MethodExecutionHandler
+import party.morino.mineauth.core.plugin.execution.MethodExecutionHandlerFactory
+import party.morino.mineauth.core.plugin.route.AuthenticationHandler
+import party.morino.mineauth.core.plugin.route.ParameterResolver
+import party.morino.mineauth.core.plugin.route.RouteExecutor
+import java.util.concurrent.TimeUnit
+import kotlin.reflect.typeOf
+
+/**
+ * http.route（HTTPサーバースパン名）の補正を実リクエストで検証する統合テスト
+ *
+ * KtorServerTelemetryを実際にインストールし、InMemorySpanExporterに出力されたスパン名・属性を検証する。
+ * これにより以下を一度に確認する:
+ * - ハンドラ内のContext.current()がサーバースパンのContextを保持していること（伝播）
+ * - HttpServerRouteSourceの優先度によりルートが上書きされること
+ * - 認証セレクタ由来のノイズが除去されること
+ * - PluginEndpointDispatcherが本番コードでルート補正・属性付与を行うこと
+ */
+class HttpRouteSpanNameTest {
+
+    private val exporter = InMemorySpanExporter.create()
+    private val tracerProvider = SdkTracerProvider.builder()
+        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+        .build()
+    private val openTelemetry = OpenTelemetrySdk.builder()
+        .setTracerProvider(tracerProvider)
+        .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+        .build()
+
+    @AfterEach
+    fun tearDown() {
+        tracerProvider.shutdown()
+    }
+
+    /** SERVERスパンを1件取得する（子スパンはINTERNAL/CLIENTのため除外される） */
+    private fun serverSpan(): SpanData {
+        tracerProvider.forceFlush().join(5, TimeUnit.SECONDS)
+        return exporter.finishedSpanItems.first { it.kind == SpanKind.SERVER }
+    }
+
+    /** テスト用のダミーハンドラ（メソッド参照のためだけに存在する） */
+    private class DummyHandler {
+        fun handle(): String = "ok"
+    }
+
+    /**
+     * 本物のPluginEndpointDispatcherを構築する
+     * メソッド実行はフェイクのファクトリで差し替え、テレメトリの配線だけを検証する
+     */
+    private fun buildDispatcher(): PluginEndpointDispatcher {
+        val handler = DummyHandler()
+        val endpoint = EndpointMetadata(
+            method = handler::handle,
+            handlerInstance = handler,
+            path = "/shops/{id}",
+            pathSegments = listOf(PathSegment.Literal("shops"), PathSegment.Param("id")),
+            httpMethod = HttpMethodType.GET,
+            access = EndpointAccess.Public(null),
+            parameters = emptyList(),
+            isSuspending = false,
+            responseType = typeOf<String>(),
+            returnsEither = false
+        )
+        val executor = RouteExecutor(
+            ParameterResolver(Json),
+            object : MethodExecutionHandlerFactory {
+                override fun createHandler(metadata: EndpointMetadata): MethodExecutionHandler =
+                    object : MethodExecutionHandler {
+                        override suspend fun execute(
+                            metadata: EndpointMetadata,
+                            resolvedParams: List<Any?>
+                        ): Either<ExecutionError, Any?> = Either.Right("ok")
+                    }
+            }
+        )
+        return PluginEndpointDispatcher(executor, AuthenticationHandler()).apply {
+            install("vault", NamespaceTable("VaultPlugin", "/api/v1/plugins/vault", listOf(endpoint)))
+        }
+    }
+
+    @Test
+    @DisplayName("Dispatcher overrides span name and enriches attributes for the matched endpoint")
+    fun dispatcherOverridesSpanNameAndEnrichesAttributes() = testApplication {
+        val dispatcher = buildDispatcher()
+        application {
+            install(Authentication) { bearer("test-auth") { authenticate { null } } }
+            install(KtorServerTelemetry) { setOpenTelemetry(openTelemetry) }
+            installAuthRouteSanitizer()
+            routing {
+                // WebServerと同一構成: 認証で包んだ単一のキャッチオールをディスパッチャに委譲する
+                authenticate("test-auth", strategy = AuthenticationStrategy.Optional) {
+                    route("/api/v1/plugins/{namespace}/{path...}") {
+                        handle { dispatcher.dispatch(call) }
+                    }
+                }
+            }
+        }
+
+        val response = client.get("/api/v1/plugins/vault/shops/123")
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val span = serverSpan()
+        // 実エンドポイントのテンプレートに補正され、認証セレクタが消えていること
+        assertEquals("GET /api/v1/plugins/vault/shops/{id}", span.name)
+        assertFalse(span.name.contains("authenticate"), "span name must not contain the authenticate selector")
+        // ディスパッチャがサーバースパンに識別属性を付与していること
+        assertEquals("vault", span.attributes.get(TelemetryAttributes.PLUGIN_NAMESPACE))
+        assertEquals("VaultPlugin", span.attributes.get(TelemetryAttributes.PLUGIN_OWNER))
+        assertEquals("/api/v1/plugins/vault/shops/{id}", span.attributes.get(TelemetryAttributes.ROUTE_TEMPLATE))
+        assertEquals("public", span.attributes.get(TelemetryAttributes.ENDPOINT_ACCESS))
+        // 認証ヘッダー無しの公開エンドポイントなのでanonymous
+        assertEquals("anonymous", span.attributes.get(TelemetryAttributes.CALLER_TYPE))
+    }
+
+    @Test
+    @DisplayName("Auth route sanitizer removes the authenticate selector from span name")
+    fun authRouteSanitizerRemovesSelector() = testApplication {
+        application {
+            install(Authentication) { bearer("test-auth") { authenticate { null } } }
+            install(KtorServerTelemetry) { setOpenTelemetry(openTelemetry) }
+            installAuthRouteSanitizer()
+            routing {
+                authenticate("test-auth", strategy = AuthenticationStrategy.Optional) {
+                    get("/hello") {
+                        call.respondText("hi")
+                    }
+                }
+            }
+        }
+
+        val response = client.get("/hello")
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val span = serverSpan()
+        // サニタイザにより認証セレクタが除去され、素直なルートになること
+        assertEquals("GET /hello", span.name)
+        assertFalse(span.name.contains("authenticate"), "span name must not contain the authenticate selector")
+    }
+
+    @Test
+    @DisplayName("Without sanitizer the authenticate selector pollutes the span name")
+    fun withoutSanitizerSelectorPollutesSpanName() = testApplication {
+        application {
+            install(Authentication) { bearer("test-auth") { authenticate { null } } }
+            install(KtorServerTelemetry) { setOpenTelemetry(openTelemetry) }
+            // あえてサニタイザを入れない: バグ（汚染）が再現することを固定する
+            routing {
+                authenticate("test-auth", strategy = AuthenticationStrategy.Optional) {
+                    get("/hello") {
+                        call.respondText("hi")
+                    }
+                }
+            }
+        }
+
+        val response = client.get("/hello")
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        // サニタイザが無い場合、スパン名に認証セレクタが混入することを確認する
+        val span = serverSpan()
+        assertTrue(span.name.contains("authenticate")) {
+            "expected polluted span name to contain the authenticate selector but was: ${span.name}"
+        }
+    }
+}

--- a/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/HttpRouteSupportTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/HttpRouteSupportTest.kt
@@ -1,0 +1,40 @@
+package party.morino.mineauth.core.web.telemetry
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * sanitizeAuthRouteのテスト
+ * 認証セレクタ由来のセグメントが除去されることを検証する
+ */
+class HttpRouteSupportTest {
+
+    @Test
+    @DisplayName("Strips leading authenticate selector")
+    fun stripsLeadingAuthenticateSelector() {
+        val polluted = "/(authenticate user-oauth-token, service-oauth-token)/api/v1/plugins/{namespace}"
+        assertEquals("/api/v1/plugins/{namespace}", sanitizeAuthRoute(polluted))
+    }
+
+    @Test
+    @DisplayName("Strips authenticate selector in the middle of the path")
+    fun stripsMiddleAuthenticateSelector() {
+        val polluted = "/api/v1/commons/(authenticate service-oauth-token)/server/plugins"
+        assertEquals("/api/v1/commons/server/plugins", sanitizeAuthRoute(polluted))
+    }
+
+    @Test
+    @DisplayName("Strips default provider authenticate selector")
+    fun stripsDefaultAuthenticateSelector() {
+        val polluted = "/(authenticate \"default\")/hello"
+        assertEquals("/hello", sanitizeAuthRoute(polluted))
+    }
+
+    @Test
+    @DisplayName("Leaves routes without authenticate selectors unchanged")
+    fun leavesCleanRouteUnchanged() {
+        val clean = "/api/v1/plugins/vault/shops/{id}"
+        assertEquals(clean, sanitizeAuthRoute(clean))
+    }
+}

--- a/docs/content/docs/contributer/telemetry.mdx
+++ b/docs/content/docs/contributer/telemetry.mdx
@@ -11,6 +11,15 @@ MineAuth uses OpenTelemetry for distributed tracing and metrics. This page descr
 - `KtorServerTelemetry` automatically creates one HTTP server span per inbound request. Manual spans created inside request handlers become children of that server span.
 - Micrometer metrics are registered once on a `CompositeMeterRegistry` that fans out to the Prometheus registry (`/metrics`) and, when enabled, to the OpenTelemetry bridge (OTLP export).
 
+## HTTP Server Span Names (`http.route`)
+
+`KtorServerTelemetry` derives the server span name from the matched Ktor route. Because routes wrapped in `authenticate { ... }` carry an authentication selector in their string representation, the raw span name leaks that selector — for example `GET /(authenticate user-oauth-token, service-oauth-token)/api/v1/plugins/{namespace}`. Two mechanisms correct this:
+
+- **Route sanitizer** (`installAuthRouteSanitizer` in `HttpRouteSupport.kt`) subscribes to `RoutingRoot.RoutingCallStarted` and re-publishes `http.route` with the authentication selector stripped, using `HttpServerRouteSource.CONTROLLER`. Since `CONTROLLER` outranks the library's `SERVER` source, the cleaned route always wins regardless of subscription order. This applies to every authenticated route (`/hello`, `/api/v1/commons/**`, OAuth endpoints).
+- **Plugin route refinement** happens in `PluginEndpointDispatcher`. Addon endpoints are all served by a single catch-all Ktor route (`/api/v1/plugins/{namespace}/{path...}`), so the resolved route cannot distinguish one addon endpoint from another. Once the dispatcher matches a request to a registered endpoint it overrides `http.route` with the actual template (for example `/api/v1/plugins/vault/shops/{id}`) using `HttpServerRouteSource.NESTED_CONTROLLER`, which outranks the sanitizer. The template is built from `NamespaceTable.basePath` plus the endpoint path, so concrete IDs never appear in the span name.
+
+When observability is disabled there is no route state on the context, and both `HttpServerRoute.update` and `Span.setAttribute` become no-ops, so these calls are always safe.
+
 ## Span Catalog
 
 | Span name | Location | Attributes |
@@ -29,6 +38,20 @@ MineAuth uses OpenTelemetry for distributed tracing and metrics. This page descr
 | `mineauth.plugin.handler` | `RouteExecutor` (all addon routes) | `mineauth.handler.class`, `mineauth.endpoint.path`, `mineauth.endpoint.method` |
 
 In addition, `respondOAuthError` records `mineauth.oauth.error_code` and sets the span status to `ERROR` on the current span for every OAuth error response.
+
+### Addon request enrichment
+
+For addon endpoints, `PluginEndpointDispatcher` also enriches the surrounding **HTTP server span** (not a child span) so the top-level request is filterable by plugin and endpoint:
+
+| Attribute | Value |
+|-----------|-------|
+| `mineauth.plugin.namespace` | URL namespace of the addon (for example `vault`) |
+| `mineauth.plugin.owner` | Name of the plugin that registered the namespace |
+| `mineauth.route.template` | Matched route template (for example `/api/v1/plugins/vault/shops/{id}`) |
+| `mineauth.endpoint.access` | `public` or `authenticated` |
+| `mineauth.auth.caller_type` | `user`, `service`, or `anonymous` |
+
+These attributes are set on a request only after it matches a registered endpoint, so unmatched requests (404 / 405) do not carry them.
 
 All attribute keys are defined in `TelemetryAttributes` (`core/.../web/telemetry/TelemetryAttributes.kt`).
 


### PR DESCRIPTION
## Summary

`KtorServerTelemetry` derives the HTTP server span name (`http.route`) from the matched Ktor route. Routes wrapped in `authenticate { }` leak the authentication selector string into that route, so plugin endpoints showed up in OTel as:

```
GET /(authenticate user-oauth-token, service-oauth-token)/api/v1/plugins/{namespace}
```

This fixes the pollution for **all** authenticated routes and, for plugin endpoints, replaces the useless catch-all route with the actual endpoint template plus richer attributes.

## Changes

- **`HttpRouteSupport.kt`** (new): `sanitizeAuthRoute` (pure) + `installAuthRouteSanitizer`. Strips `(authenticate …)` segments from `http.route` for every authenticated route, re-published with `HttpServerRouteSource.CONTROLLER` (outranks the library's `SERVER`).
- **`PluginEndpointDispatcher`**: once a request matches a registered endpoint, overrides `http.route` with the real template (e.g. `/api/v1/plugins/vault/shops/{id}`) via `NESTED_CONTROLLER`, and enriches the HTTP server span with new attributes.
- **`TelemetryAttributes`**: `mineauth.plugin.namespace`, `mineauth.plugin.owner`, `mineauth.route.template`, `mineauth.endpoint.access`, `mineauth.auth.caller_type`.
- **`WebServer.module()`**: wires the sanitizer after installing `KtorServerTelemetry` (only when observability is enabled).
- Docs: `contributer/telemetry.mdx` documents the `http.route` correction and the new attributes.

## Span source ordering

`SERVER`(2) < `CONTROLLER`(3) < `NESTED_CONTROLLER`(4). The sanitizer (CONTROLLER) always beats the library (SERVER); the dispatcher (NESTED_CONTROLLER) always beats the sanitizer regardless of route length, so even root endpoints refine correctly.

## Tests

- `HttpRouteSupportTest`: pure `sanitizeAuthRoute` edge cases (leading / middle / default-provider / clean).
- `HttpRouteSpanNameTest`: real-request integration with `KtorServerTelemetry` + in-memory exporter.
  - Drives the **real** `PluginEndpointDispatcher.dispatch()` and asserts the overridden span name **and** all five enrichment attributes.
  - Confirms the sanitizer removes the selector for non-plugin authenticated routes (`/hello`).
  - Baseline test pins the bug (without the sanitizer the selector pollutes the span name).

Reviewed with a multi-agent adversarial pass; the one confirmed finding (integration test didn't exercise the real dispatcher) is addressed.

## Notes

- Behavior is telemetry-only; request handling is unchanged. When observability is disabled, `HttpServerRoute.update` / `Span.setAttribute` are safe no-ops.
- OTel traces only — Micrometer metrics still use Ktor's own route resolution (separate follow-up if per-endpoint metrics are wanted).
