### PR TITLE
🐛 Fix plugin http.route not refining on Jetty and template url.path (PII)

### DIFF
--- a/core/src/main/kotlin/party/morino/mineauth/core/plugin/dispatch/PluginEndpointDispatcher.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/plugin/dispatch/PluginEndpointDispatcher.kt
@@ -6,11 +6,12 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.context.Context
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource
 import org.koin.core.component.KoinComponent
 import party.morino.mineauth.api.auth.Principal
+import party.morino.mineauth.core.web.telemetry.OTEL_ROUTE_TEMPLATE
+import party.morino.mineauth.core.web.telemetry.otelServerContext
 import party.morino.mineauth.core.plugin.annotation.EndpointAccess
 import party.morino.mineauth.core.plugin.annotation.EndpointMetadata
 import party.morino.mineauth.core.plugin.annotation.HttpMethodType
@@ -141,15 +142,20 @@ class PluginEndpointDispatcher(
         // 上書きすることで、エンドポイント単位で識別・集計できるようにする。
         // NESTED_CONTROLLER(order=4)はサニタイザのCONTROLLER(order=3)より優先度が高いため、
         // ルート文字列の長短に関わらず必ずこの値が採用される。
+        // サーバースパンのContextはハンドラのコルーチンでは失われることがあるため、
+        // call.attributesに保存された確実なContextを使う（Context.current()に頼らない）
+        val otelContext = call.otelServerContext()
         val routeTemplate = table.basePath + endpoint.path
         HttpServerRoute.update(
-            Context.current(),
+            otelContext,
             HttpServerRouteSource.NESTED_CONTROLLER,
             routeTemplate
         )
+        // url.pathテンプレート化用に、より具体的なテンプレートで退避を上書きする
+        call.attributes.put(OTEL_ROUTE_TEMPLATE, routeTemplate)
         // サーバースパンにプラグイン・ルートの識別属性を付与する（トップレベルHTTPスパンを検索可能にする）
-        // トレーシング無効時はSpan.current()がNoOpとなり、setAttributeは安全に無視される
-        Span.current().apply {
+        // トレーシング無効時はSpanがNoOpとなり、setAttributeは安全に無視される
+        Span.fromContext(otelContext).apply {
             setAttribute(TelemetryAttributes.PLUGIN_NAMESPACE, namespace)
             setAttribute(TelemetryAttributes.PLUGIN_OWNER, table.pluginName)
             setAttribute(TelemetryAttributes.ROUTE_TEMPLATE, routeTemplate)
@@ -176,7 +182,7 @@ class PluginEndpointDispatcher(
         }
 
         // 認証結果が確定したので、呼び出し元の種別をサーバースパンに記録する
-        Span.current().setAttribute(TelemetryAttributes.CALLER_TYPE, callerTypeLabel(principal))
+        Span.fromContext(otelContext).setAttribute(TelemetryAttributes.CALLER_TYPE, callerTypeLabel(principal))
 
         // ハンドラーを実行
         executor.execute(RequestContext(call, principal, pathParams), endpoint)

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/WebServer.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/WebServer.kt
@@ -45,10 +45,12 @@ import party.morino.mineauth.core.web.router.common.CommonRouter.commonRouter
 import party.morino.mineauth.core.web.router.plugin.PluginRouter.pluginRouter
 import party.morino.mineauth.core.plugin.dispatch.PluginEndpointDispatcher
 import party.morino.mineauth.core.web.telemetry.MinecraftMetrics
+import party.morino.mineauth.core.web.telemetry.OTEL_ROUTE_TEMPLATE
 import party.morino.mineauth.core.web.telemetry.TelemetryAttributes
 import party.morino.mineauth.core.web.telemetry.TelemetryProvider
 import party.morino.mineauth.core.web.telemetry.installAuthRouteSanitizer
 import party.morino.mineauth.core.web.telemetry.withSpan
+import io.opentelemetry.semconv.UrlAttributes
 import java.security.KeyStore
 import java.util.concurrent.TimeUnit
 
@@ -102,6 +104,15 @@ internal fun Application.module() {
     if (observabilityConfig.enabled) {
         install(KtorServerTelemetry) {
             setOpenTelemetry(openTelemetry)
+            // url.pathには具体パス（例: /api/v1/plugins/vault/balance/_NIKOMARU）がそのまま入り、
+            // プレイヤー名などのPIIを含む。算出済みのルートテンプレートで置換してPIIを除去する。
+            attributesExtractor {
+                onEnd {
+                    request.call.attributes.getOrNull(OTEL_ROUTE_TEMPLATE)?.let { template ->
+                        attributes.put(UrlAttributes.URL_PATH, template)
+                    }
+                }
+            }
         }
         // KtorServerTelemetryが設定するhttp.routeから認証セレクタ由来のノイズ
         // （例: "(authenticate user-oauth-token, service-oauth-token)"）を除去する

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/HttpRouteSupport.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/telemetry/HttpRouteSupport.kt
@@ -1,8 +1,10 @@
 package party.morino.mineauth.core.web.telemetry
 
 import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.routing.RoutingNode
 import io.ktor.server.routing.RoutingRoot
+import io.ktor.util.AttributeKey
 import io.opentelemetry.context.Context
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource
@@ -25,6 +27,28 @@ import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource
 // 認証ルートセレクタの`toString()`形式（例: "(authenticate user-oauth-token, service-oauth-token)"）
 // プロバイダ名にスラッシュは含まれないため、1つのパスセグメント全体がこの形にマッチする
 private val AUTHENTICATE_SELECTOR = Regex("""\(authenticate .*\)""")
+
+// サニタイザ（RoutingCallStarted）で捕捉したサーバースパンのContextをcall.attributesへ退避するキー。
+// RoutingCallStartedの時点ではContext.current()が確実にサーバースパンを保持するため、そこで捕捉する。
+private val OTEL_SERVER_CONTEXT: AttributeKey<Context> = AttributeKey("mineauth.otel.server_context")
+
+// url.pathをテンプレート化するために、算出済みのルートテンプレートをcall.attributesに退避するキー。
+// onEnd（スパン終了時）に読み出して、具体パス（プレイヤー名などのPII）をテンプレートで置換する。
+val OTEL_ROUTE_TEMPLATE: AttributeKey<String> = AttributeKey("mineauth.otel.route_template")
+
+/**
+ * KtorServerTelemetryが確立したサーバースパンのOpenTelemetry Contextを取得する
+ *
+ * ハンドラのコルーチンでは、認証インターセプタ等でのスレッド切り替えにより
+ * `Context.current()`がサーバースパンのContextを失うことがある（本番Jettyで顕在化）。
+ * そのため、サニタイザ（RoutingCallStarted）でContextが確実な時点に捕捉して
+ * call.attributesへ退避しておき、それを優先して返す。無い場合のみ`Context.current()`にフォールバックする。
+ *
+ * @receiver ApplicationCall
+ * @return サーバースパンのContext（トレーシング無効時はrootのContext）
+ */
+fun ApplicationCall.otelServerContext(): Context =
+    attributes.getOrNull(OTEL_SERVER_CONTEXT) ?: Context.current()
 
 /**
  * ルート文字列から認証セレクタ由来のセグメントを取り除く
@@ -60,10 +84,14 @@ fun Application.installAuthRouteSanitizer() {
     monitor.subscribe(RoutingRoot.RoutingCallStarted) { call ->
         // マッチしたルートの親（メソッドセレクタを除いた部分）を起点にサニタイズする
         val parent: RoutingNode = call.route.parent ?: return@subscribe
-        HttpServerRoute.update(
-            Context.current(),
-            HttpServerRouteSource.CONTROLLER,
-            sanitizeAuthRoute(parent.toString())
-        )
+        val sanitized = sanitizeAuthRoute(parent.toString())
+        // RoutingCallStartedの時点ではContext.current()が確実にサーバースパンを保持する。
+        // ハンドラのコルーチンでは失われることがあるため、ここで捕捉して退避しておき、
+        // ディスパッチャ（handle内）はこの退避済みContextを使ってルートを補正する。
+        val serverContext = Context.current()
+        call.attributes.put(OTEL_SERVER_CONTEXT, serverContext)
+        HttpServerRoute.update(serverContext, HttpServerRouteSource.CONTROLLER, sanitized)
+        // url.pathテンプレート化用に退避（プラグインエンドポイントはディスパッチャがより具体的な値で上書きする）
+        call.attributes.put(OTEL_ROUTE_TEMPLATE, sanitized)
     }
 }

--- a/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/HttpRouteJettyTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/HttpRouteJettyTest.kt
@@ -1,0 +1,165 @@
+package party.morino.mineauth.core.web.telemetry
+
+import arrow.core.Either
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.java.Java
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.server.application.install
+import io.ktor.server.auth.*
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.jetty.jakarta.Jetty
+import io.ktor.server.routing.*
+import kotlinx.coroutines.withContext
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.extension.kotlin.asContextElement
+import io.opentelemetry.instrumentation.ktor.v3_0.KtorServerTelemetry
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.opentelemetry.semconv.HttpAttributes
+import io.opentelemetry.semconv.UrlAttributes
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import party.morino.mineauth.core.plugin.annotation.EndpointAccess
+import party.morino.mineauth.core.plugin.annotation.EndpointMetadata
+import party.morino.mineauth.core.plugin.annotation.HttpMethodType
+import party.morino.mineauth.core.plugin.annotation.PathSegment
+import party.morino.mineauth.core.plugin.dispatch.NamespaceTable
+import party.morino.mineauth.core.plugin.dispatch.PluginEndpointDispatcher
+import party.morino.mineauth.core.plugin.execution.ExecutionError
+import party.morino.mineauth.core.plugin.execution.MethodExecutionHandler
+import party.morino.mineauth.core.plugin.execution.MethodExecutionHandlerFactory
+import party.morino.mineauth.core.plugin.route.AuthenticationHandler
+import party.morino.mineauth.core.plugin.route.ParameterResolver
+import party.morino.mineauth.core.plugin.route.RouteExecutor
+import java.util.concurrent.TimeUnit
+import kotlin.reflect.typeOf
+
+/**
+ * 本番と同じJettyエンジンでhttp.routeの補正を検証する統合テスト
+ *
+ * testApplicationのテストエンジンではコルーチンのContext伝播が本番と異なり、
+ * ハンドラ内のContext.current()がサーバースパンを保持してしまう（＝偽陽性）。
+ * このテストは実Jettyサーバーを起動し、実HTTPリクエストでhttp.route属性を検証することで、
+ * ディスパッチャのルート補正が本番エンジン上でも機能することを保証する。
+ */
+class HttpRouteJettyTest {
+
+    private val exporter = InMemorySpanExporter.create()
+    private val tracerProvider = SdkTracerProvider.builder()
+        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+        .build()
+    private val openTelemetry = OpenTelemetrySdk.builder()
+        .setTracerProvider(tracerProvider)
+        .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+        .build()
+
+    @AfterEach
+    fun tearDown() {
+        tracerProvider.shutdown()
+    }
+
+    private class DummyHandler {
+        fun handle(): String = "ok"
+    }
+
+    /** 公開エンドポイント /balance/{player} を1件登録した本物のディスパッチャを構築する */
+    private fun buildDispatcher(): PluginEndpointDispatcher {
+        val handler = DummyHandler()
+        val endpoint = EndpointMetadata(
+            method = handler::handle,
+            handlerInstance = handler,
+            path = "/balance/{player}",
+            pathSegments = listOf(PathSegment.Literal("balance"), PathSegment.Param("player")),
+            httpMethod = HttpMethodType.GET,
+            access = EndpointAccess.Public(null),
+            parameters = emptyList(),
+            isSuspending = false,
+            responseType = typeOf<String>(),
+            returnsEither = false
+        )
+        val executor = RouteExecutor(
+            ParameterResolver(Json),
+            object : MethodExecutionHandlerFactory {
+                override fun createHandler(metadata: EndpointMetadata): MethodExecutionHandler =
+                    object : MethodExecutionHandler {
+                        override suspend fun execute(
+                            metadata: EndpointMetadata,
+                            resolvedParams: List<Any?>
+                        ): Either<ExecutionError, Any?> = Either.Right("ok")
+                    }
+            }
+        )
+        return PluginEndpointDispatcher(executor, AuthenticationHandler()).apply {
+            install("vault", NamespaceTable("VaultPlugin", "/api/v1/plugins/vault", listOf(endpoint)))
+        }
+    }
+
+    private fun serverSpan(): SpanData {
+        tracerProvider.forceFlush().join(5, TimeUnit.SECONDS)
+        return exporter.finishedSpanItems.first { it.kind == SpanKind.SERVER }
+    }
+
+    @Test
+    @DisplayName("Dispatcher refines http.route on the real Jetty engine")
+    fun dispatcherRefinesRouteOnJetty() {
+        val dispatcher = buildDispatcher()
+        val server = embeddedServer(Jetty, port = 0) {
+            install(Authentication) { bearer("test-auth") { authenticate { null } } }
+            install(KtorServerTelemetry) {
+                setOpenTelemetry(openTelemetry)
+                attributesExtractor {
+                    onEnd {
+                        request.call.attributes.getOrNull(OTEL_ROUTE_TEMPLATE)?.let { template ->
+                            attributes.put(io.opentelemetry.semconv.UrlAttributes.URL_PATH, template)
+                        }
+                    }
+                }
+            }
+            installAuthRouteSanitizer()
+            routing {
+                authenticate("test-auth", strategy = AuthenticationStrategy.Optional) {
+                    route("/api/v1/plugins/{namespace}/{path...}") {
+                        handle {
+                            // 本番では認証インターセプタ等のスレッド切り替えでハンドラのContext.current()が
+                            // サーバースパンを失うことがある。ここでは明示的にrootのContextを現在にして
+                            // その状況を決定的に再現する。Context.current()に頼る実装はここで失敗する。
+                            withContext(Context.root().asContextElement()) {
+                                dispatcher.dispatch(call)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        server.start(wait = false)
+        try {
+            val port = runBlocking { server.engine.resolvedConnectors().first().port }
+            val client = HttpClient(Java)
+            val body = runBlocking {
+                client.get("http://localhost:$port/api/v1/plugins/vault/balance/_NIKOMARU").bodyAsText()
+            }
+            client.close()
+            assertEquals("ok", body)
+
+            val span = serverSpan()
+            // 本番エンジン上でも実エンドポイントのテンプレートに補正されること
+            assertEquals("/api/v1/plugins/vault/balance/{player}", span.attributes.get(HttpAttributes.HTTP_ROUTE))
+            assertEquals("GET /api/v1/plugins/vault/balance/{player}", span.name)
+            // url.pathもテンプレート化され、具体的なプレイヤー名（PII）が含まれないこと
+            assertEquals("/api/v1/plugins/vault/balance/{player}", span.attributes.get(UrlAttributes.URL_PATH))
+        } finally {
+            server.stop(0, 0, TimeUnit.SECONDS)
+        }
+    }
+}

--- a/docs/content/docs/contributer/telemetry.mdx
+++ b/docs/content/docs/contributer/telemetry.mdx
@@ -16,9 +16,17 @@ MineAuth uses OpenTelemetry for distributed tracing and metrics. This page descr
 `KtorServerTelemetry` derives the server span name from the matched Ktor route. Because routes wrapped in `authenticate { ... }` carry an authentication selector in their string representation, the raw span name leaks that selector — for example `GET /(authenticate user-oauth-token, service-oauth-token)/api/v1/plugins/{namespace}`. Two mechanisms correct this:
 
 - **Route sanitizer** (`installAuthRouteSanitizer` in `HttpRouteSupport.kt`) subscribes to `RoutingRoot.RoutingCallStarted` and re-publishes `http.route` with the authentication selector stripped, using `HttpServerRouteSource.CONTROLLER`. Since `CONTROLLER` outranks the library's `SERVER` source, the cleaned route always wins regardless of subscription order. This applies to every authenticated route (`/hello`, `/api/v1/commons/**`, OAuth endpoints).
-- **Plugin route refinement** happens in `PluginEndpointDispatcher`. Addon endpoints are all served by a single catch-all Ktor route (`/api/v1/plugins/{namespace}/{path...}`), so the resolved route cannot distinguish one addon endpoint from another. Once the dispatcher matches a request to a registered endpoint it overrides `http.route` with the actual template (for example `/api/v1/plugins/vault/shops/{id}`) using `HttpServerRouteSource.NESTED_CONTROLLER`, which outranks the sanitizer. The template is built from `NamespaceTable.basePath` plus the endpoint path, so concrete IDs never appear in the span name.
+- **Plugin route refinement** happens in `PluginEndpointDispatcher`. Addon endpoints are all served by a single catch-all Ktor route (`/api/v1/plugins/{namespace}/{path...}`), so the resolved route cannot distinguish one addon endpoint from another. Once the dispatcher matches a request to a registered endpoint it overrides `http.route` with the actual template (for example `/api/v1/plugins/vault/balance/{player}`) using `HttpServerRouteSource.NESTED_CONTROLLER`, which outranks the sanitizer. The template is built from `NamespaceTable.basePath` plus the endpoint path, so concrete IDs never appear in the span name.
 
-When observability is disabled there is no route state on the context, and both `HttpServerRoute.update` and `Span.setAttribute` become no-ops, so these calls are always safe.
+### Server-span context capture
+
+Updating `http.route` and setting span attributes both require the OpenTelemetry context that holds the server span. Inside the request handler coroutine `Context.current()` is **not** reliable — under the Jetty engine an authentication interceptor can switch threads and leave `Context.current()` without the server span, so `HttpServerRoute.update` would silently no-op. To avoid this, the sanitizer captures `Context.current()` at `RoutingRoot.RoutingCallStarted` (where it is guaranteed to hold the server span) and stashes it in `call.attributes`. `ApplicationCall.otelServerContext()` reads it back, so the dispatcher never depends on the handler-thread context. `RoutingCall.attributes` is the same bag across the routing pipeline, so the value survives into the handler.
+
+### `url.path` templating
+
+`KtorServerTelemetry` records `url.path` as the concrete request path (e.g. `/api/v1/plugins/vault/balance/_Steve`), which embeds player names — PII under the rules below. An `attributesExtractor { onEnd { … } }` on the telemetry plugin overwrites `url.path` with the resolved route template stashed in `call.attributes` (`OTEL_ROUTE_TEMPLATE`), so `url.path` becomes `/api/v1/plugins/vault/balance/{player}` and never carries the concrete identifier.
+
+When observability is disabled there is no route state on the context, and `HttpServerRoute.update`, `Span.setAttribute`, and the attribute extractor all become no-ops, so these calls are always safe.
 
 ## Span Catalog
 


### PR DESCRIPTION
## Summary

Follow-up to #374. In production (Jetty) the plugin `http.route` override from #374 **silently no-op'd**, so plugin endpoints kept showing the catch-all route:

```
http.route: /api/v1/plugins/{namespace}      ← should be /api/v1/plugins/vault/balance/{player}
url.path:   /api/v1/plugins/vault/balance/_Steve   ← concrete player name (PII)
```

### Root cause

`PluginEndpointDispatcher` called `HttpServerRoute.update(Context.current(), …)` from inside the handler coroutine. Under the Jetty engine an authentication interceptor switches threads, and by the time the handler runs `Context.current()` no longer holds the server span. `HttpServerRoute.update` then finds no route state and does nothing — so the sanitizer's generic `/api/v1/plugins/{namespace}` survives. `testApplication` (used in #374's tests) does not switch threads, which is why the bug slipped through.

### Fix

- **Capture the server-span context where it is reliable.** The sanitizer runs at `RoutingRoot.RoutingCallStarted` (before the handler thread switch) where `Context.current()` is guaranteed to hold the server span. It stashes that context in `call.attributes`; `ApplicationCall.otelServerContext()` reads it back, so the dispatcher no longer depends on the handler-thread context. `RoutingCall.attributes` is shared across the routing pipeline, so the value survives into the handler.
- **Template `url.path`.** An `attributesExtractor { onEnd { … } }` overwrites `url.path` with the resolved route template, so the concrete request path (which embeds player names = PII per the telemetry policy) is replaced with `/api/v1/plugins/vault/balance/{player}`.

### Tests

- **`HttpRouteJettyTest`** (new): starts a **real Jetty server** and makes a real HTTP request. It deterministically reproduces the handler context loss by wrapping the dispatch in `withContext(Context.root().asContextElement())` — this **fails** against the #374 code and **passes** with this fix. Asserts `http.route`, span name, and templated `url.path`.
- Existing testApplication + unit tests still pass (17 telemetry tests total, 0 failures).

### Notes

- Behavior is telemetry-only; request handling is unchanged. All calls are safe no-ops when observability is disabled.
- Belongs in the 0.3.0 line together with #374.
