### PR TITLE
✨ Response headers, conditional 304, and standalone/softDepend audit (#375)

### DIFF
--- a/api/src/main/kotlin/party/morino/mineauth/api/MineAuthApi.kt
+++ b/api/src/main/kotlin/party/morino/mineauth/api/MineAuthApi.kt
@@ -53,8 +53,20 @@ interface MineAuthApi {
         /**
          * ServicesManagerからMineAuthApiのインスタンスを取得する
          *
+         * この`null`は「MineAuthはロード済みだがサービス登録がまだ」という
+         * ロード順の狭い窓のみを表す。**MineAuthが存在しない**場合には`null`は返らない：
+         * `get`を呼ぶ時点でJVMが`MineAuthApi`クラスの解決を試み、
+         * `softDepend`＋`compileOnly`構成でMineAuthが不在ならクラスが見つからず
+         * 呼び出し箇所で`NoClassDefFoundError`となる（bodyの`null`返却には到達しない）。
+         *
+         * したがって`get(server) ?: error(...)`のような例は、MineAuthの存在が保証される
+         * ハード`depend`前提でのみ安全である。オプション依存（softDepend）の場合は、
+         * まずBukkitレベルで`server.pluginManager.getPlugin("MineAuth") != null`を確認し、
+         * APIに触れるコードを別クラスへ隔離すること
+         * （developer/addons/optional-dependency を参照）。
+         *
          * @param server Bukkitサーバーインスタンス
-         * @return MineAuthApi、MineAuthが未ロードの場合はnull
+         * @return MineAuthApi、サービス未登録の場合はnull（不在時は例外、上記参照）
          */
         @JvmStatic
         fun get(server: Server): MineAuthApi? =

--- a/api/src/main/kotlin/party/morino/mineauth/api/annotations/Conditional.kt
+++ b/api/src/main/kotlin/party/morino/mineauth/api/annotations/Conditional.kt
@@ -1,0 +1,30 @@
+package party.morino.mineauth.api.annotations
+
+/**
+ * 条件付きリクエスト情報（[party.morino.mineauth.api.http.ConditionalRequest]）を受け取る
+ * パラメータを定義するアノテーション
+ *
+ * ハンドラーは注入された`ConditionalRequest`から`If-None-Match`ヘッダーの値を参照し、
+ * 高価なボディ生成の**前に**安価なETag（バージョンやタイムスタンプ）を比較することで、
+ * キャッシュヒット時にボディ生成そのものをスキップできる（真の304短絡）。
+ *
+ * ```kotlin
+ * @Get("/shops/{id}")
+ * @Public
+ * suspend fun getShop(
+ *     @Path("id") id: String,
+ *     @Conditional cond: ConditionalRequest
+ * ): Either<HttpError, Response<ShopDto>> = either {
+ *     val version = repo.versionOf(id) ?: raise(HttpError(HttpStatus.NOT_FOUND, "not found"))
+ *     val etag = "\"shop-$id-$version\""
+ *     if (cond.isNoneMatch(etag)) return@either Response.notModified(etag)
+ *     Response.of(repo.loadFull(id).toDto(), etag = etag)
+ * }
+ * ```
+ *
+ * バインドできる型は`ConditionalRequest`のみ（non-nullable）。
+ * `@Public`・`@Authenticated`どちらのエンドポイントでも使用できる。
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Conditional

--- a/api/src/main/kotlin/party/morino/mineauth/api/http/CacheControl.kt
+++ b/api/src/main/kotlin/party/morino/mineauth/api/http/CacheControl.kt
@@ -1,0 +1,58 @@
+package party.morino.mineauth.api.http
+
+/**
+ * `Cache-Control`レスポンスヘッダーを型安全に表現する値オブジェクト
+ *
+ * 読み取り専用エンドポイントのレスポンスにキャッシュ指示を付与し、クライアントや
+ * リバースプロキシ・CDNが繰り返しのリクエストをオフロードできるようにする。
+ *
+ * ```kotlin
+ * Response.of(dto, cacheControl = CacheControl.maxAge(60))          // private, max-age=60
+ * Response.of(dto, cacheControl = CacheControl.maxAge(300, PUBLIC)) // public, max-age=300
+ * ```
+ *
+ * @property visibility キャッシュの可視性（`public` / `private`）
+ * @property maxAgeSeconds `max-age`（秒）。nullなら付与しない
+ * @property noStore `no-store`（一切キャッシュしない）
+ * @property noCache `no-cache`（再検証を要求する）
+ * @property mustRevalidate `must-revalidate`
+ */
+data class CacheControl(
+    val visibility: Visibility = Visibility.PRIVATE,
+    val maxAgeSeconds: Long? = null,
+    val noStore: Boolean = false,
+    val noCache: Boolean = false,
+    val mustRevalidate: Boolean = false
+) {
+    /** キャッシュの可視性 */
+    enum class Visibility { PUBLIC, PRIVATE }
+
+    /**
+     * `Cache-Control`ヘッダーの値へ変換する（例: `private, max-age=60`）
+     */
+    fun toHeaderValue(): String = buildList {
+        // no-storeが指定されている場合は他の指示と併記せず単独で返す
+        if (noStore) {
+            add("no-store")
+            return@buildList
+        }
+        add(if (visibility == Visibility.PUBLIC) "public" else "private")
+        if (noCache) add("no-cache")
+        maxAgeSeconds?.let { add("max-age=$it") }
+        if (mustRevalidate) add("must-revalidate")
+    }.joinToString(", ")
+
+    companion object {
+        /**
+         * `max-age`を指定したキャッシュ指示を生成する
+         *
+         * @param seconds キャッシュ有効秒数
+         * @param visibility 可視性（既定は`private`）
+         */
+        fun maxAge(seconds: Long, visibility: Visibility = Visibility.PRIVATE): CacheControl =
+            CacheControl(visibility = visibility, maxAgeSeconds = seconds)
+
+        /** 一切キャッシュしない指示（`no-store`） */
+        val NoStore: CacheControl = CacheControl(noStore = true)
+    }
+}

--- a/api/src/main/kotlin/party/morino/mineauth/api/http/ConditionalRequest.kt
+++ b/api/src/main/kotlin/party/morino/mineauth/api/http/ConditionalRequest.kt
@@ -1,0 +1,53 @@
+package party.morino.mineauth.api.http
+
+/**
+ * 条件付きリクエスト（HTTP conditional request）の情報を提供する読み取り専用オブジェクト
+ *
+ * `@Conditional`パラメータとしてハンドラーに注入される。ハンドラーは高価なボディ生成の
+ * **前に**安価なETagを計算し、[isNoneMatch]で`If-None-Match`と照合することで、
+ * キャッシュヒット時に[Response.notModified]を返してボディ生成・直列化の双方をスキップできる。
+ *
+ * v1では`If-None-Match`のみを扱う（`If-Modified-Since`は未対応）。
+ *
+ * @property ifNoneMatch リクエストの`If-None-Match`ヘッダーから抽出したETag値のリスト
+ */
+class ConditionalRequest internal constructor(
+    private val ifNoneMatch: List<String>
+) {
+    /**
+     * 指定したETagが`If-None-Match`に一致するか判定する（RFC 7232準拠）
+     *
+     * - `*` はあらゆるETagに一致する
+     * - 弱いバリデータ（`W/"..."`）は弱い比較で照合する
+     *   （条件付きGETでは弱い比較が許容される）
+     *
+     * @param etag 比較対象のETag（引用符付きの完全な形式、例: `"shop-1-42"` や `W/"v3"`）
+     * @return 一致すれば true（呼び出し側は304を返すべき）
+     */
+    fun isNoneMatch(etag: String): Boolean {
+        if (ifNoneMatch.isEmpty()) return false
+        if (ifNoneMatch.any { it == "*" }) return true
+        val target = weakUnwrap(etag)
+        return ifNoneMatch.any { weakUnwrap(it) == target }
+    }
+
+    /** `W/`接頭辞を除去して弱い比較用に正規化する */
+    private fun weakUnwrap(value: String): String =
+        value.removePrefix("W/").trim()
+
+    companion object {
+        /**
+         * `If-None-Match`ヘッダー値（複数ヘッダー・カンマ区切りの両方）をETagのリストへ解析する
+         *
+         * @param headerValues `getAll("If-None-Match")`等で得た生のヘッダー値
+         * @return 空白を除去したETagのリスト
+         */
+        fun fromHeaderValues(headerValues: List<String>): ConditionalRequest =
+            ConditionalRequest(
+                headerValues
+                    .flatMap { it.split(",") }
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() }
+            )
+    }
+}

--- a/api/src/main/kotlin/party/morino/mineauth/api/http/HttpStatus.kt
+++ b/api/src/main/kotlin/party/morino/mineauth/api/http/HttpStatus.kt
@@ -7,6 +7,7 @@ enum class HttpStatus(val code: Int) {
     OK(200),
     CREATED(201),
     NO_CONTENT(204),
+    NOT_MODIFIED(304),
     BAD_REQUEST(400),
     UNAUTHORIZED(401),
     FORBIDDEN(403),

--- a/api/src/main/kotlin/party/morino/mineauth/api/http/Response.kt
+++ b/api/src/main/kotlin/party/morino/mineauth/api/http/Response.kt
@@ -1,0 +1,97 @@
+package party.morino.mineauth.api.http
+
+/**
+ * レスポンスヘッダー（`Cache-Control` / `ETag`）や条件付き304を制御するためのハンドラー戻り値ラッパー
+ *
+ * ハンドラーは生の`@Serializable` DTOをそのまま返すことも、この`Response<T>`でラップして
+ * キャッシュ指示やETagを付与することもできる。`Either<HttpError, Response<T>>`のように
+ * Arrowの`Either`と組み合わせても使える（`out T`により[NotModified]も同じ式で返せる）。
+ *
+ * ```kotlin
+ * // 単純なキャッシュ付きレスポンス
+ * @Get("/config") @Public
+ * suspend fun config(): Response<ConfigDto> =
+ *     Response.of(loadConfig(), etag = configEtag(), cacheControl = CacheControl.maxAge(60))
+ *
+ * // 条件付き304（安価なETagで高価なボディ生成をスキップ）
+ * @Get("/shops/{id}") @Public
+ * suspend fun getShop(@Path("id") id: String, @Conditional cond: ConditionalRequest): Either<HttpError, Response<ShopDto>> = either {
+ *     val version = repo.versionOf(id) ?: raise(HttpError(HttpStatus.NOT_FOUND, "not found"))
+ *     val etag = "\"shop-$id-$version\""
+ *     if (cond.isNoneMatch(etag)) return@either Response.notModified(etag)
+ *     Response.of(repo.loadFull(id).toDto(), etag = etag, cacheControl = CacheControl.maxAge(60))
+ * }
+ * ```
+ *
+ * ボディは常に**具体化された値**として保持する（`() -> T`のようなラムダは保持しない）。
+ * 利用側クラスローダのラムダをMineAuthが呼び出すとクラスローダ分裂（issue #378と同種）を
+ * 招くため、遅延ボディはv1では意図的に提供しない。
+ *
+ * @property etag レスポンスの`ETag`ヘッダー値（引用符付きの完全な形式、nullなら付与しない）
+ * @property cacheControl `Cache-Control`ヘッダー（nullなら付与しない）
+ * @property headers 追加のレスポンスヘッダー
+ */
+sealed interface Response<out T> {
+    val etag: String?
+    val cacheControl: CacheControl?
+    val headers: Map<String, String>
+
+    /**
+     * ボディを伴う成功レスポンス
+     *
+     * @property status HTTPステータス（既定は200 OK）
+     * @property body 直列化対象のボディ（具体化された値）
+     */
+    class Ok<out T> internal constructor(
+        val status: HttpStatus,
+        val body: T,
+        override val etag: String?,
+        override val cacheControl: CacheControl?,
+        override val headers: Map<String, String>
+    ) : Response<T>
+
+    /**
+     * ボディを持たない304 Not Modifiedレスポンス
+     *
+     * `out T`により`Response<Nothing>`として任意の`Response<T>`の位置に代入できる。
+     */
+    class NotModified internal constructor(
+        override val etag: String?,
+        override val cacheControl: CacheControl?,
+        override val headers: Map<String, String>
+    ) : Response<Nothing>
+
+    companion object {
+        /**
+         * ボディ付きの成功レスポンスを生成する
+         *
+         * @param body 直列化対象のボディ
+         * @param etag `ETag`（任意、引用符付きの完全な形式）
+         * @param cacheControl `Cache-Control`（任意）
+         * @param status HTTPステータス（既定は200 OK）
+         * @param headers 追加ヘッダー（任意）
+         */
+        fun <T> of(
+            body: T,
+            etag: String? = null,
+            cacheControl: CacheControl? = null,
+            status: HttpStatus = HttpStatus.OK,
+            headers: Map<String, String> = emptyMap()
+        ): Response<T> = Ok(status, body, etag, cacheControl, headers)
+
+        /**
+         * 304 Not Modifiedレスポンスを生成する
+         *
+         * ハンドラーが`If-None-Match`との一致を検出したときに返す。ボディ生成・直列化は行われない。
+         *
+         * @param etag 一致したETag（304レスポンスにも付与される）
+         * @param cacheControl `Cache-Control`（任意）
+         * @param headers 追加ヘッダー（任意）
+         */
+        fun notModified(
+            etag: String,
+            cacheControl: CacheControl? = null,
+            headers: Map<String, String> = emptyMap()
+        ): Response<Nothing> = NotModified(etag, cacheControl, headers)
+    }
+}

--- a/core/src/main/kotlin/party/morino/mineauth/core/openapi/generator/SchemaGenerator.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/openapi/generator/SchemaGenerator.kt
@@ -1,16 +1,13 @@
 package party.morino.mineauth.core.openapi.generator
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 import org.bukkit.OfflinePlayer
 import org.bukkit.entity.Player
 import org.koin.core.component.KoinComponent
 import party.morino.mineauth.core.openapi.model.Schema
 import java.util.UUID
+import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
-import kotlin.reflect.full.findAnnotation
-import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.full.memberProperties
 
 /**
@@ -18,6 +15,12 @@ import kotlin.reflect.full.memberProperties
  * Kotlinのリフレクションを使用して型情報からJSONスキーマを構築する
  */
 class SchemaGenerator : KoinComponent {
+
+    companion object {
+        // クラスローダ非依存にするため、シリアライズ用アノテーションは完全修飾名で判定する
+        private const val KOTLINX_SERIALIZABLE = "kotlinx.serialization.Serializable"
+        private const val KOTLINX_SERIAL_NAME = "kotlinx.serialization.SerialName"
+    }
 
     /**
      * KTypeからOpenAPIスキーマを生成する
@@ -95,7 +98,7 @@ class SchemaGenerator : KoinComponent {
             // 列挙型
             else -> if (classifier.java.isEnum) {
                 generateEnumSchema(classifier)
-            } else if (classifier.hasAnnotation<Serializable>()) {
+            } else if (classifier.hasSerializableAnnotation()) {
                 // @Serializable付きデータクラス
                 generateObjectSchema(classifier, processingTypes)
             } else {
@@ -148,7 +151,7 @@ class SchemaGenerator : KoinComponent {
             // データクラスのプロパティを反復処理
             for (prop in kClass.memberProperties) {
                 // @SerialNameがあればその名前を使用、なければプロパティ名
-                val serialName = prop.findAnnotation<SerialName>()?.value ?: prop.name
+                val serialName = prop.serialNameValue() ?: prop.name
                 val propSchema = generateSchemaInternal(prop.returnType, processingTypes)
                 properties[serialName] = propSchema
 
@@ -167,6 +170,32 @@ class SchemaGenerator : KoinComponent {
             processingTypes.remove(kClass)
         }
     }
+
+    /**
+     * `@Serializable`が付与されているかをFQNで判定する
+     *
+     * `hasAnnotation<Serializable>()`はMineAuth本体の`Serializable` Classに対する
+     * instanceof判定のため、利用側がserializationをshadeしたDTO（別クラスローダの
+     * `@Serializable`）を認識できずスキーマを空オブジェクトに縮退させてしまう（issue #378関連）。
+     * クラスローダ非依存にするため、完全修飾名で判定する。
+     */
+    private fun KAnnotatedElement.hasSerializableAnnotation(): Boolean =
+        annotations.any { it.annotationClass.qualifiedName == KOTLINX_SERIALIZABLE }
+
+    /**
+     * `@SerialName`の値をFQNで取得する（付与されていなければnull）
+     *
+     * [hasSerializableAnnotation]と同様にクラスローダ分裂に耐えるよう、完全修飾名で
+     * アノテーションを探し、値はリフレクションで読み取る（利用側クラスローダの
+     * `SerialName` Classへは直接キャストできないため）。
+     */
+    private fun KAnnotatedElement.serialNameValue(): String? =
+        annotations.firstOrNull { it.annotationClass.qualifiedName == KOTLINX_SERIAL_NAME }
+            ?.let { annotation ->
+                runCatching {
+                    annotation.annotationClass.java.getMethod("value").invoke(annotation) as? String
+                }.getOrNull()
+            }
 
     /**
      * 戻り値の型からレスポンススキーマを生成する

--- a/core/src/main/kotlin/party/morino/mineauth/core/plugin/annotation/AnnotationProcessor.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/plugin/annotation/AnnotationProcessor.kt
@@ -14,6 +14,7 @@ import party.morino.mineauth.api.RegistrationError
 import party.morino.mineauth.api.annotations.Authenticated
 import party.morino.mineauth.api.annotations.Body
 import party.morino.mineauth.api.annotations.Caller
+import party.morino.mineauth.api.annotations.Conditional
 import party.morino.mineauth.api.annotations.Delete
 import party.morino.mineauth.api.annotations.Get
 import party.morino.mineauth.api.annotations.Patch
@@ -26,6 +27,7 @@ import party.morino.mineauth.api.annotations.Query
 import party.morino.mineauth.api.annotations.QueryMap
 import party.morino.mineauth.api.annotations.Route
 import party.morino.mineauth.api.auth.Principal
+import party.morino.mineauth.api.http.ConditionalRequest
 import party.morino.mineauth.api.http.HttpError
 import party.morino.mineauth.core.plugin.serialization.PluginSerialization
 import java.util.UUID
@@ -57,6 +59,9 @@ class AnnotationProcessor : KoinComponent {
             Double::class, Float::class, Boolean::class, UUID::class
         )
         private val CONVERTIBLE_TYPE_NAMES = CONVERTIBLE_TYPES.map { it.simpleName ?: "?" }
+
+        // レスポンスラッパーの完全修飾名（本体提供のAPI型なので直接比較でよい）
+        private const val RESPONSE_QUALIFIED_NAME = "party.morino.mineauth.api.http.Response"
     }
 
     /**
@@ -139,7 +144,8 @@ class AnnotationProcessor : KoinComponent {
                         isSuspending = function.isSuspend,
                         responseType = returnInfo.responseType,
                         returnsEither = returnInfo.returnsEither,
-                        responseResolvableByCore = returnInfo.resolvableByCore
+                        responseResolvableByCore = returnInfo.resolvableByCore,
+                        returnsResponse = returnInfo.returnsResponse
                     )
                 )
             }
@@ -248,7 +254,8 @@ class AnnotationProcessor : KoinComponent {
             param.hasAnnotation<QueryMap>(),
             param.hasAnnotation<Body>(),
             param.hasAnnotation<Caller>(),
-            param.hasAnnotation<PlayerParam>()
+            param.hasAnnotation<PlayerParam>(),
+            param.hasAnnotation<Conditional>()
         ).count { it }
 
         if (annotationCount == 0) {
@@ -275,6 +282,9 @@ class AnnotationProcessor : KoinComponent {
 
             param.hasAnnotation<Caller>() ->
                 analyzeCaller(className, function, param, access, errors)
+
+            param.hasAnnotation<Conditional>() ->
+                analyzeConditional(className, function, param, errors)
 
             else ->
                 analyzePlayerParam(className, function, param, access, segments, path, errors)
@@ -484,6 +494,30 @@ class AnnotationProcessor : KoinComponent {
     }
 
     /**
+     * @Conditionalパラメータを解析する
+     * ConditionalRequest型のみ許可し、@Public・@Authenticatedどちらでも使用できる
+     */
+    private fun analyzeConditional(
+        className: String,
+        function: KFunction<*>,
+        param: KParameter,
+        errors: MutableList<RegistrationError>
+    ): ParameterInfo? {
+        val paramName = param.name ?: "unknown"
+
+        // バインド型はConditionalRequestのみ（non-nullable）
+        if (param.type.jvmErasure != ConditionalRequest::class || param.type.isMarkedNullable) {
+            errors += RegistrationError.UnsupportedParameterType(
+                className, function.name, paramName,
+                param.type.toString(), listOf("ConditionalRequest (non-nullable)")
+            )
+            return null
+        }
+
+        return ParameterInfo.Conditional
+    }
+
+    /**
      * @PlayerParamパラメータを解析する
      * OfflinePlayer型のみ、@Authenticatedエンドポイントのみで使用可能
      */
@@ -544,21 +578,24 @@ class AnnotationProcessor : KoinComponent {
     /**
      * 戻り値型の解析結果
      *
-     * @property responseType レスポンス型（Eitherの場合は右側の型）
+     * @property responseType 直列化対象のレスポンス型（Either・Responseを剥がした後の内側の型）
      * @property returnsEither 戻り値がArrowのEitherかどうか
+     * @property returnsResponse 戻り値が`Response<T>`ラッパーかどうか
      * @property resolvableByCore レスポンス型をMineAuth本体のランタイムで直列化できるか
      */
     private data class ReturnTypeInfo(
         val responseType: KType,
         val returnsEither: Boolean,
+        val returnsResponse: Boolean,
         val resolvableByCore: Boolean
     )
 
     /**
      * 戻り値型を解析する
-     * Either<HttpError, T>の場合はTをレスポンス型として抽出する。
-     * 抽出したレスポンス型がシリアライズ可能かを登録時に検証し、実行時の不透明な
-     * 500ではなく明快な登録エラーとして早期に検出する（[validateResponseSerializable]）。
+     *
+     * `Either<HttpError, T>`の場合はTを、さらにTが`Response<U>`ラッパーの場合はUを
+     * 直列化対象のレスポンス型として抽出する。抽出した型がシリアライズ可能かを登録時に検証し、
+     * 実行時の不透明な500ではなく明快な登録エラーとして早期に検出する（[validateResponseSerializable]）。
      */
     private fun analyzeReturnType(
         className: String,
@@ -569,11 +606,11 @@ class AnnotationProcessor : KoinComponent {
         val returnType = function.returnType
         val classifierName = (returnType.classifier as? KClass<*>)?.qualifiedName
 
-        // ArrowのEitherかどうかを判定
+        // まずEither<HttpError, T>を剥がす
         // shade/relocate対応のため接尾辞比較とするが、パッケージ境界を含めて誤判定を防ぐ
-        if (classifierName != null &&
+        val returnsEither = classifierName != null &&
             (classifierName == "arrow.core.Either" || classifierName.endsWith(".arrow.core.Either"))
-        ) {
+        val innerType = if (returnsEither) {
             // 左側の型はHttpErrorである必要がある
             val leftType = returnType.arguments.getOrNull(0)?.type
             if (leftType?.jvmErasure != HttpError::class) {
@@ -582,13 +619,22 @@ class AnnotationProcessor : KoinComponent {
                     "Either return type must be Either<HttpError, T> (got left type $leftType)"
                 )
             }
-            val rightType = returnType.arguments.getOrNull(1)?.type ?: typeOf<Any?>()
-            val resolvableByCore = validateResponseSerializable(className, function, rightType, consumerClassLoader, errors)
-            return ReturnTypeInfo(rightType, returnsEither = true, resolvableByCore = resolvableByCore)
+            returnType.arguments.getOrNull(1)?.type ?: typeOf<Any?>()
+        } else {
+            returnType
         }
 
-        val resolvableByCore = validateResponseSerializable(className, function, returnType, consumerClassLoader, errors)
-        return ReturnTypeInfo(returnType, returnsEither = false, resolvableByCore = resolvableByCore)
+        // 次にResponse<U>ラッパーを剥がす（Responseは本体が提供するAPI型なので直接FQN比較でよい）
+        val innerClassifierName = (innerType.classifier as? KClass<*>)?.qualifiedName
+        val returnsResponse = innerClassifierName == RESPONSE_QUALIFIED_NAME
+        val responseType = if (returnsResponse) {
+            innerType.arguments.getOrNull(0)?.type ?: typeOf<Any?>()
+        } else {
+            innerType
+        }
+
+        val resolvableByCore = validateResponseSerializable(className, function, responseType, consumerClassLoader, errors)
+        return ReturnTypeInfo(responseType, returnsEither, returnsResponse, resolvableByCore)
     }
 
     /**

--- a/core/src/main/kotlin/party/morino/mineauth/core/plugin/annotation/EndpointMetadata.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/plugin/annotation/EndpointMetadata.kt
@@ -126,6 +126,12 @@ sealed class ParameterInfo {
      * @property access アクセスポリシー
      */
     data class TargetPlayer(val segment: String, val access: PlayerAccess) : ParameterInfo()
+
+    /**
+     * 条件付きリクエスト情報（`ConditionalRequest`）の注入
+     * `If-None-Match`ヘッダーを参照して条件付き304を実現するために使う（payloadなし）
+     */
+    data object Conditional : ParameterInfo()
 }
 
 /**
@@ -145,6 +151,9 @@ sealed class ParameterInfo {
  * @property responseResolvableByCore レスポンス型をMineAuth本体のランタイムで直列化できるか。
  *   登録時に一度だけ判定し、リクエスト時の直列化経路（本体 or 利用側クラスローダ）を決める。
  *   falseの場合は利用側がserializationをshadeしていると判断し利用側クラスローダで直列化する。
+ * @property returnsResponse 戻り値が`Response<T>`ラッパー（Eitherの右側も含む）かどうか。
+ *   trueの場合、[responseType]はラップされた内側の型Tを指し、実行時にラッパーを展開して
+ *   ヘッダー・ETag・条件付き304を処理する。
  */
 data class EndpointMetadata(
     val method: KFunction<*>,
@@ -157,5 +166,6 @@ data class EndpointMetadata(
     val isSuspending: Boolean,
     val responseType: KType,
     val returnsEither: Boolean,
-    val responseResolvableByCore: Boolean
+    val responseResolvableByCore: Boolean,
+    val returnsResponse: Boolean
 )

--- a/core/src/main/kotlin/party/morino/mineauth/core/plugin/route/ParameterResolver.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/plugin/route/ParameterResolver.kt
@@ -12,6 +12,7 @@ import org.bukkit.Bukkit
 import org.koin.core.component.KoinComponent
 import party.morino.mineauth.api.PlayerAccess
 import party.morino.mineauth.api.auth.Principal
+import party.morino.mineauth.api.http.ConditionalRequest
 import party.morino.mineauth.core.plugin.annotation.CallerKind
 import party.morino.mineauth.core.plugin.annotation.ParameterInfo
 import party.morino.mineauth.core.plugin.serialization.PluginSerialization
@@ -52,8 +53,18 @@ class ParameterResolver(
             is ParameterInfo.Body -> resolveBody(context, paramInfo).bind()
             is ParameterInfo.Caller -> resolveCaller(context, paramInfo).bind()
             is ParameterInfo.TargetPlayer -> resolveTargetPlayer(context, paramInfo).bind()
+            is ParameterInfo.Conditional -> resolveConditional(context)
         }
     }
+
+    /**
+     * 条件付きリクエスト情報を解決する
+     * `If-None-Match`ヘッダー（複数ヘッダー・カンマ区切りの両方）を解析して注入する
+     */
+    private fun resolveConditional(context: RequestContext): ConditionalRequest =
+        ConditionalRequest.fromHeaderValues(
+            context.call.request.headers.getAll("If-None-Match").orEmpty()
+        )
 
     /**
      * パスパラメータを解決する

--- a/core/src/main/kotlin/party/morino/mineauth/core/plugin/route/RouteExecutor.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/plugin/route/RouteExecutor.kt
@@ -2,6 +2,7 @@ package party.morino.mineauth.core.plugin.route
 
 import arrow.core.Either
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
@@ -10,8 +11,12 @@ import io.ktor.util.reflect.TypeInfo
 import io.opentelemetry.api.common.Attributes
 import org.koin.core.component.KoinComponent
 import org.slf4j.LoggerFactory
+import party.morino.mineauth.api.http.CacheControl
+import party.morino.mineauth.api.http.ConditionalRequest
 import party.morino.mineauth.api.http.HttpError
+import party.morino.mineauth.api.http.Response
 import party.morino.mineauth.core.plugin.annotation.EndpointMetadata
+import party.morino.mineauth.core.plugin.annotation.HttpMethodType
 import party.morino.mineauth.core.plugin.execution.ExecutionError
 import party.morino.mineauth.core.plugin.execution.MethodExecutionHandlerFactory
 import party.morino.mineauth.core.plugin.serialization.PluginSerialization
@@ -123,12 +128,65 @@ class RouteExecutor(
         when (value) {
             null -> call.respond(HttpStatusCode.NoContent)
             is Unit -> call.respond(HttpStatusCode.OK)
+            // ハンドラーが明示的に返した304（Tier-B: ボディ生成前に短絡済み）
+            is Response.NotModified -> respondNotModified(call, value.etag, value.cacheControl, value.headers)
+            // Responseラッパー（ヘッダー・ETag・条件付き304の制御付き）
+            is Response.Ok<*> -> respondResponseOk(call, value, metadata)
             else -> respondSerialized(call, value, metadata)
         }
     }
 
     /**
-     * 戻り値をレスポンスとして返す
+     * [Response.Ok]をHTTPレスポンスにする
+     *
+     * 条件付きGET（`If-None-Match`がETagに一致）の場合はボディ直列化を省いて304を返す（Tier-A短絡）。
+     * それ以外はキャッシュ指示・ヘッダーを**成功パスにのみ**付与してボディを直列化する。
+     *
+     * @param call ApplicationCall
+     * @param ok レスポンスラッパー
+     * @param metadata エンドポイントメタデータ（responseTypeは内側のボディ型）
+     */
+    private suspend fun respondResponseOk(call: ApplicationCall, ok: Response.Ok<*>, metadata: EndpointMetadata) {
+        val etag = ok.etag
+        // Tier-A: 条件付きGETでETagが一致すれば直列化を省略して304を返す
+        if (etag != null && metadata.httpMethod == HttpMethodType.GET && matchesIfNoneMatch(call, etag)) {
+            respondNotModified(call, etag, ok.cacheControl, ok.headers)
+            return
+        }
+
+        val directives = CacheDirectives(etag, ok.cacheControl, ok.headers)
+        val status = HttpStatusCode.fromValue(ok.status.code)
+        when (val body = ok.body) {
+            null -> { directives.applyTo(call); call.respond(HttpStatusCode.NoContent) }
+            is Unit -> { directives.applyTo(call); call.respond(status) }
+            else -> respondSerialized(call, body, metadata, status, directives)
+        }
+    }
+
+    /**
+     * 304 Not Modifiedを返す（ボディなし、キャッシュ指示は付与する）
+     */
+    private suspend fun respondNotModified(
+        call: ApplicationCall,
+        etag: String?,
+        cacheControl: CacheControl?,
+        headers: Map<String, String>
+    ) {
+        CacheDirectives(etag, cacheControl, headers).applyTo(call)
+        call.respond(HttpStatusCode.NotModified)
+    }
+
+    /**
+     * リクエストの`If-None-Match`が指定ETagに一致するか判定する
+     * [ConditionalRequest]と同一のRFC 7232準拠ロジックを共有する
+     */
+    private fun matchesIfNoneMatch(call: ApplicationCall, etag: String): Boolean =
+        ConditionalRequest.fromHeaderValues(
+            call.request.headers.getAll("If-None-Match").orEmpty()
+        ).isNoneMatch(etag)
+
+    /**
+     * 戻り値をJSONへ直列化してレスポンスとして返す
      *
      * まずMineAuth本体のランタイムでシリアライザを解決できるかを確認し、可能なら
      * 既存どおり`call.respond(value, TypeInfo)`で返す（String等のKtor特殊型の扱いを含め
@@ -142,12 +200,24 @@ class RouteExecutor(
      * @param call ApplicationCall
      * @param value 直列化する戻り値（非null）
      * @param metadata エンドポイントメタデータ
+     * @param status レスポンスステータス（既定はOK）
+     * @param directives 付与するキャッシュ指示・ヘッダー（成功パスにのみ適用、nullなら付与しない）
      */
-    private suspend fun respondSerialized(call: ApplicationCall, value: Any, metadata: EndpointMetadata) {
+    private suspend fun respondSerialized(
+        call: ApplicationCall,
+        value: Any,
+        metadata: EndpointMetadata,
+        status: HttpStatusCode = HttpStatusCode.OK,
+        directives: CacheDirectives? = null
+    ) {
         // 標準パス：MineAuth自身のランタイムで解決できるなら既存挙動を完全に維持する
         // 解決可否は登録時に判定済み（[EndpointMetadata.responseResolvableByCore]）で、
         // リクエスト時に serializer(KType) を呼ばないため例外がパイプラインへ漏れることはない
         if (metadata.responseResolvableByCore) {
+            // このパスはresolvableByCore=trueなので直列化はまず失敗しない。
+            // ヘッダーはrespondの直前に付与する（万一の失敗時のヘッダー漏れは実質発生しない）
+            directives?.applyTo(call)
+            if (status != HttpStatusCode.OK) call.response.status(status)
             call.respond(value, resolveTypeInfo(metadata))
             return
         }
@@ -169,7 +239,30 @@ class RouteExecutor(
             respondInternalServerError(call)
             return
         }
-        call.respondText(jsonText, ContentType.Application.Json, HttpStatusCode.OK)
+        // 直列化に成功してからヘッダーを付与する（失敗時の500にキャッシュヘッダーが漏れない）
+        directives?.applyTo(call)
+        call.respondText(jsonText, ContentType.Application.Json, status)
+    }
+
+    /**
+     * レスポンスに付与するキャッシュ指示・追加ヘッダー
+     *
+     * [applyTo]を成功パスでのみ呼ぶことで、直列化失敗時の500へヘッダーが漏れないようにする。
+     */
+    private class CacheDirectives(
+        private val etag: String?,
+        private val cacheControl: CacheControl?,
+        private val headers: Map<String, String>
+    ) {
+        fun applyTo(call: ApplicationCall) {
+            etag?.let { call.response.headers.append(HttpHeaders.ETag, it, safeOnly = false) }
+            cacheControl?.let {
+                call.response.headers.append(HttpHeaders.CacheControl, it.toHeaderValue(), safeOnly = false)
+            }
+            headers.forEach { (name, headerValue) ->
+                call.response.headers.append(name, headerValue, safeOnly = false)
+            }
+        }
     }
 
     /** Eitherアンラップの結果を表すsealed class */

--- a/core/src/main/kotlin/party/morino/mineauth/core/plugin/route/RouteExecutor.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/plugin/route/RouteExecutor.kt
@@ -260,8 +260,18 @@ class RouteExecutor(
                 call.response.headers.append(HttpHeaders.CacheControl, it.toHeaderValue(), safeOnly = false)
             }
             headers.forEach { (name, headerValue) ->
-                call.response.headers.append(name, headerValue, safeOnly = false)
+                // レスポンスのフレーミングを壊すヘッダーは利用側が上書きできないようにする
+                if (name.lowercase() !in FRAMING_HEADERS) {
+                    call.response.headers.append(name, headerValue, safeOnly = false)
+                }
             }
+        }
+
+        companion object {
+            // 直列化・転送のフレーミングを決めるヘッダー（利用側の任意ヘッダーからは除外する）
+            private val FRAMING_HEADERS = setOf(
+                "content-type", "content-length", "transfer-encoding", "connection"
+            )
         }
     }
 

--- a/core/src/test/kotlin/party/morino/mineauth/core/http/CacheControlTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/http/CacheControlTest.kt
@@ -1,0 +1,45 @@
+package party.morino.mineauth.core.http
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import party.morino.mineauth.api.http.CacheControl
+
+/**
+ * [CacheControl]のヘッダー文字列化のテスト
+ */
+class CacheControlTest {
+
+    @Test
+    @DisplayName("maxAge renders private by default")
+    fun maxAgePrivate() {
+        assertEquals("private, max-age=60", CacheControl.maxAge(60).toHeaderValue())
+    }
+
+    @Test
+    @DisplayName("maxAge renders public when requested")
+    fun maxAgePublic() {
+        assertEquals(
+            "public, max-age=300",
+            CacheControl.maxAge(300, CacheControl.Visibility.PUBLIC).toHeaderValue()
+        )
+    }
+
+    @Test
+    @DisplayName("no-store is rendered alone")
+    fun noStoreAlone() {
+        assertEquals("no-store", CacheControl.NoStore.toHeaderValue())
+    }
+
+    @Test
+    @DisplayName("no-cache and must-revalidate are combined")
+    fun combinedDirectives() {
+        val cc = CacheControl(
+            visibility = CacheControl.Visibility.PUBLIC,
+            maxAgeSeconds = 10,
+            noCache = true,
+            mustRevalidate = true
+        )
+        assertEquals("public, no-cache, max-age=10, must-revalidate", cc.toHeaderValue())
+    }
+}

--- a/core/src/test/kotlin/party/morino/mineauth/core/http/ConditionalRequestTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/http/ConditionalRequestTest.kt
@@ -1,0 +1,53 @@
+package party.morino.mineauth.core.http
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import party.morino.mineauth.api.http.ConditionalRequest
+
+/**
+ * [ConditionalRequest.isNoneMatch]のRFC 7232準拠の照合テスト
+ */
+class ConditionalRequestTest {
+
+    @Test
+    @DisplayName("Empty If-None-Match never matches")
+    fun emptyNeverMatches() {
+        assertFalse(ConditionalRequest.fromHeaderValues(emptyList()).isNoneMatch("\"v1\""))
+    }
+
+    @Test
+    @DisplayName("Exact etag matches")
+    fun exactMatch() {
+        assertTrue(ConditionalRequest.fromHeaderValues(listOf("\"v1\"")).isNoneMatch("\"v1\""))
+    }
+
+    @Test
+    @DisplayName("Non-matching etag does not match")
+    fun noMatch() {
+        assertFalse(ConditionalRequest.fromHeaderValues(listOf("\"v1\"")).isNoneMatch("\"v2\""))
+    }
+
+    @Test
+    @DisplayName("Wildcard matches any etag")
+    fun wildcardMatches() {
+        assertTrue(ConditionalRequest.fromHeaderValues(listOf("*")).isNoneMatch("\"anything\""))
+    }
+
+    @Test
+    @DisplayName("Comma-separated list matches any member")
+    fun commaListMatches() {
+        val cond = ConditionalRequest.fromHeaderValues(listOf("\"a\", \"b\", \"c\""))
+        assertTrue(cond.isNoneMatch("\"b\""))
+        assertFalse(cond.isNoneMatch("\"z\""))
+    }
+
+    @Test
+    @DisplayName("Weak validators match by weak comparison")
+    fun weakComparison() {
+        // 条件付きGETでは弱いバリデータ同士・強弱混在を弱い比較で一致とみなす
+        assertTrue(ConditionalRequest.fromHeaderValues(listOf("W/\"v1\"")).isNoneMatch("\"v1\""))
+        assertTrue(ConditionalRequest.fromHeaderValues(listOf("\"v1\"")).isNoneMatch("W/\"v1\""))
+    }
+}

--- a/core/src/test/kotlin/party/morino/mineauth/core/openapi/generator/SchemaGeneratorClassLoaderTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/openapi/generator/SchemaGeneratorClassLoaderTest.kt
@@ -1,6 +1,7 @@
 package party.morino.mineauth.core.openapi.generator
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
@@ -57,5 +58,22 @@ class SchemaGeneratorClassLoaderTest {
         assertTrue(schema.properties!!.containsKey("count"))
         // non-nullableプロパティは必須
         assertEquals(setOf("name", "count"), schema.required?.toSet())
+    }
+
+    @Test
+    @DisplayName("Shaded @SerialName remaps the property name via reflective read")
+    fun shadedSerialNameRemapped() {
+        val serialNameDtoFq = "party.morino.mineauth.core.openapi.generator.SerialNameSampleDto"
+        val cl = IsolatingClassLoader(javaClass.classLoader, serialNameDtoFq)
+        val isolatedDto = cl.loadClass(serialNameDtoFq)
+
+        val schema = SchemaGenerator().generateSchema(isolatedDto.kotlin.starProjectedType)
+
+        // 別クラスローダの@SerialNameでもリフレクションで値を読み取り、名前がリマップされること
+        assertNotNull(schema.properties)
+        assertTrue(schema.properties!!.containsKey("display_name"), "must use @SerialName value")
+        assertFalse(schema.properties!!.containsKey("displayName"), "must not use the Kotlin property name")
+        assertTrue(schema.properties!!.containsKey("count"))
+        assertEquals(setOf("display_name", "count"), schema.required?.toSet())
     }
 }

--- a/core/src/test/kotlin/party/morino/mineauth/core/openapi/generator/SchemaGeneratorClassLoaderTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/openapi/generator/SchemaGeneratorClassLoaderTest.kt
@@ -1,0 +1,61 @@
+package party.morino.mineauth.core.openapi.generator
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import kotlin.reflect.full.starProjectedType
+
+/**
+ * 利用側プラグインがserializationをshadeしたDTOに対するスキーマ生成のテスト（issue #378関連の監査）
+ *
+ * 従来は`hasAnnotation<Serializable>()`がMineAuth本体の`Serializable` Classに対する
+ * instanceof判定だったため、別クラスローダの`@Serializable`を認識できず、対象DTOのスキーマが
+ * プロパティ無しの空オブジェクトに黙って縮退していた。FQN判定への変更でこれを解消する。
+ */
+class SchemaGeneratorClassLoaderTest {
+
+    private val dtoFqName = "party.morino.mineauth.core.plugin.serialization.SampleResponseDto"
+
+    /** `kotlinx.serialization.*` とDTOを child-first で再ロードする分離クラスローダー */
+    private class IsolatingClassLoader(
+        parent: ClassLoader,
+        private val isolatedPrefix: String
+    ) : ClassLoader(parent) {
+        private fun shouldIsolate(name: String): Boolean =
+            name.startsWith("kotlinx.serialization.") || name.startsWith(isolatedPrefix)
+
+        override fun loadClass(name: String, resolve: Boolean): Class<*> {
+            if (!shouldIsolate(name)) return super.loadClass(name, resolve)
+            synchronized(getClassLoadingLock(name)) {
+                findLoadedClass(name)?.let {
+                    if (resolve) resolveClass(it)
+                    return it
+                }
+                val bytes = parent.getResourceAsStream(name.replace('.', '/') + ".class")
+                    ?.use { it.readBytes() } ?: throw ClassNotFoundException(name)
+                val clazz = defineClass(name, bytes, 0, bytes.size)
+                if (resolve) resolveClass(clazz)
+                return clazz
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Shaded @Serializable DTO yields properties, not an empty object")
+    fun shadedDtoSchemaHasProperties() {
+        val cl = IsolatingClassLoader(javaClass.classLoader, dtoFqName)
+        val isolatedDto = cl.loadClass(dtoFqName)
+
+        val schema = SchemaGenerator().generateSchema(isolatedDto.kotlin.starProjectedType)
+
+        assertEquals("object", schema.type)
+        // 別クラスローダの@Serializableでもプロパティが正しく展開されること
+        assertNotNull(schema.properties, "properties must not be null for a @Serializable DTO")
+        assertTrue(schema.properties!!.containsKey("name"))
+        assertTrue(schema.properties!!.containsKey("count"))
+        // non-nullableプロパティは必須
+        assertEquals(setOf("name", "count"), schema.required?.toSet())
+    }
+}

--- a/core/src/test/kotlin/party/morino/mineauth/core/openapi/generator/SerialNameSampleDto.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/openapi/generator/SerialNameSampleDto.kt
@@ -1,0 +1,17 @@
+package party.morino.mineauth.core.openapi.generator
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * `@SerialName`によるプロパティ名リマップを検証するためのスキーマ生成テスト用DTO
+ *
+ * 分離クラスローダーで再ロードした際、FQNベースの`@SerialName`検出とリフレクションによる
+ * 値読み取りが機能することを確認する。
+ */
+@Serializable
+data class SerialNameSampleDto(
+    @SerialName("display_name")
+    val displayName: String,
+    val count: Int
+)

--- a/core/src/test/kotlin/party/morino/mineauth/core/plugin/annotation/ResponseAndConditionalTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/plugin/annotation/ResponseAndConditionalTest.kt
@@ -1,0 +1,92 @@
+package party.morino.mineauth.core.plugin.annotation
+
+import arrow.core.Either
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import party.morino.mineauth.api.RegistrationError
+import party.morino.mineauth.api.annotations.Conditional
+import party.morino.mineauth.api.annotations.Get
+import party.morino.mineauth.api.annotations.Public
+import party.morino.mineauth.api.http.ConditionalRequest
+import party.morino.mineauth.api.http.HttpError
+import party.morino.mineauth.api.http.Response
+import party.morino.mineauth.core.plugin.serialization.SampleResponseDto
+import kotlin.reflect.jvm.jvmErasure
+
+/**
+ * issue #375: Responseラッパーの戻り値解析と@Conditionalパラメータ検証のテスト
+ */
+class ResponseAndConditionalTest {
+
+    private val processor = AnnotationProcessor()
+
+    @Test
+    @DisplayName("Response<T> return type unwraps to inner T")
+    fun responseWrapperUnwrapped() {
+        val handler = object {
+            @Get("/config")
+            @Public
+            fun config(): Response<SampleResponseDto> = Response.of(SampleResponseDto("x", 1))
+        }
+        val result = processor.process(handler)
+
+        assertTrue(result is Either.Right)
+        val endpoint = (result as Either.Right).value.single()
+        assertTrue(endpoint.returnsResponse)
+        assertFalse(endpoint.returnsEither)
+        // responseTypeはラップ内側のDTOを指す
+        assertEquals(SampleResponseDto::class, endpoint.responseType.jvmErasure)
+        assertTrue(endpoint.responseResolvableByCore)
+    }
+
+    @Test
+    @DisplayName("Either<HttpError, Response<T>> unwraps both layers")
+    fun eitherOfResponseUnwrapped() {
+        val handler = object {
+            @Get("/shop")
+            @Public
+            fun shop(): Either<HttpError, Response<SampleResponseDto>> =
+                Either.Right(Response.of(SampleResponseDto("y", 2)))
+        }
+        val result = processor.process(handler)
+
+        assertTrue(result is Either.Right)
+        val endpoint = (result as Either.Right).value.single()
+        assertTrue(endpoint.returnsResponse)
+        assertTrue(endpoint.returnsEither)
+        assertEquals(SampleResponseDto::class, endpoint.responseType.jvmErasure)
+    }
+
+    @Test
+    @DisplayName("@Conditional ConditionalRequest parameter is accepted")
+    fun conditionalParamAccepted() {
+        val handler = object {
+            @Get("/data")
+            @Public
+            fun data(@Conditional cond: ConditionalRequest): Response<SampleResponseDto> =
+                Response.of(SampleResponseDto("z", 3))
+        }
+        val result = processor.process(handler)
+
+        assertTrue(result is Either.Right)
+        val endpoint = (result as Either.Right).value.single()
+        assertTrue(endpoint.parameters.any { it is ParameterInfo.Conditional })
+    }
+
+    @Test
+    @DisplayName("@Conditional with wrong type is rejected")
+    fun conditionalWrongTypeRejected() {
+        val handler = object {
+            @Get("/bad")
+            @Public
+            fun bad(@Conditional wrong: String): SampleResponseDto = SampleResponseDto("a", 0)
+        }
+        val result = processor.process(handler)
+
+        assertTrue(result is Either.Left)
+        assertTrue((result as Either.Left).value.any { it is RegistrationError.UnsupportedParameterType })
+    }
+}

--- a/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/HttpRouteJettyTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/HttpRouteJettyTest.kt
@@ -87,7 +87,8 @@ class HttpRouteJettyTest {
             isSuspending = false,
             responseType = typeOf<String>(),
             returnsEither = false,
-            responseResolvableByCore = true
+            responseResolvableByCore = true,
+            returnsResponse = false
         )
         val executor = RouteExecutor(
             ParameterResolver(Json),

--- a/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/HttpRouteSpanNameTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/HttpRouteSpanNameTest.kt
@@ -93,7 +93,8 @@ class HttpRouteSpanNameTest {
             isSuspending = false,
             responseType = typeOf<String>(),
             returnsEither = false,
-            responseResolvableByCore = true
+            responseResolvableByCore = true,
+            returnsResponse = false
         )
         val executor = RouteExecutor(
             ParameterResolver(Json),

--- a/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/PluginResponseSerializationJettyTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/PluginResponseSerializationJettyTest.kt
@@ -95,7 +95,8 @@ class PluginResponseSerializationJettyTest {
             isSuspending = false,
             responseType = isolatedDto.kotlin.starProjectedType, // 分離DTOのKType
             returnsEither = false,
-            responseResolvableByCore = false // shade済みのため本体では解決不能→利用側クラスローダ経路
+            responseResolvableByCore = false, // shade済みのため本体では解決不能→利用側クラスローダ経路
+            returnsResponse = false
         )
         val executor = RouteExecutor(
             ParameterResolver(Json),

--- a/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/PluginResponseSerializationJettyTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/PluginResponseSerializationJettyTest.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.java.Java
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
@@ -14,12 +15,15 @@ import io.ktor.server.jetty.jakarta.Jetty
 import io.ktor.server.routing.*
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import party.morino.mineauth.core.plugin.annotation.EndpointAccess
 import party.morino.mineauth.core.plugin.annotation.EndpointMetadata
 import party.morino.mineauth.core.plugin.annotation.HttpMethodType
 import party.morino.mineauth.core.plugin.annotation.PathSegment
+import party.morino.mineauth.api.http.CacheControl
+import party.morino.mineauth.api.http.Response
 import party.morino.mineauth.core.plugin.dispatch.NamespaceTable
 import party.morino.mineauth.core.plugin.dispatch.PluginEndpointDispatcher
 import party.morino.mineauth.core.plugin.execution.ExecutionError
@@ -115,8 +119,102 @@ class PluginResponseSerializationJettyTest {
         }
     }
 
+    /**
+     * shadeされたDTOを`Response.of`でラップして返すエンドポイントを持つディスパッチャを構築する
+     * （issue #375 × #378 の交差：ラッパー使用時も利用側クラスローダ経路で直列化されること）
+     */
+    private fun buildResponseWrapperDispatcher(etag: String): PluginEndpointDispatcher {
+        val cl = IsolatingClassLoader(javaClass.classLoader, dtoFqName)
+        val isolatedDto = cl.loadClass(dtoFqName)
+        val instance = isolatedDto
+            .getConstructor(String::class.java, Int::class.javaPrimitiveType)
+            .newInstance("hello", 42)
+
+        val endpoint = EndpointMetadata(
+            method = DummyHandler::handle,
+            handlerInstance = instance,
+            path = "/data",
+            pathSegments = listOf(PathSegment.Literal("data")),
+            httpMethod = HttpMethodType.GET,
+            access = EndpointAccess.Public(null),
+            parameters = emptyList(),
+            isSuspending = false,
+            responseType = isolatedDto.kotlin.starProjectedType, // 内側DTOのKType
+            returnsEither = false,
+            responseResolvableByCore = false, // shade済み→利用側クラスローダ経路
+            returnsResponse = true
+        )
+        val executor = RouteExecutor(
+            ParameterResolver(Json),
+            object : MethodExecutionHandlerFactory {
+                override fun createHandler(metadata: EndpointMetadata): MethodExecutionHandler =
+                    object : MethodExecutionHandler {
+                        override suspend fun execute(
+                            metadata: EndpointMetadata,
+                            resolvedParams: List<Any?>
+                        ): Either<ExecutionError, Any?> = Either.Right(
+                            Response.of(instance, etag = etag, cacheControl = CacheControl.maxAge(60))
+                        )
+                    }
+            }
+        )
+        return PluginEndpointDispatcher(executor, AuthenticationHandler()).apply {
+            install("sample", NamespaceTable("SamplePlugin", "/api/v1/plugins/sample", listOf(endpoint)))
+        }
+    }
+
     private class DummyHandler {
         fun handle(): String = "unused"
+    }
+
+    private fun <T> withServer(dispatcher: PluginEndpointDispatcher, block: (Int) -> T): T {
+        val server = embeddedServer(Jetty, port = 0) {
+            install(Authentication) { bearer("test-auth") { authenticate { null } } }
+            routing {
+                authenticate("test-auth", strategy = AuthenticationStrategy.Optional) {
+                    route("/api/v1/plugins/{namespace}/{path...}") {
+                        handle { dispatcher.dispatch(call) }
+                    }
+                }
+            }
+        }
+        server.start(wait = false)
+        return try {
+            val port = runBlocking { server.engine.resolvedConnectors().first().port }
+            block(port)
+        } finally {
+            server.stop(0, 0, TimeUnit.SECONDS)
+        }
+    }
+
+    @Test
+    @DisplayName("Shaded Response<T> serializes with cache headers, and honors If-None-Match")
+    fun shadedResponseWrapperWithCaching() {
+        val etag = "\"shaded-v1\""
+        withServer(buildResponseWrapperDispatcher(etag)) { port ->
+            val client = HttpClient(Java)
+
+            // 初回GET：利用側クラスローダ経路で直列化され、ETag/Cache-Controlが付与されること
+            val first = runBlocking { client.get("http://localhost:$port/api/v1/plugins/sample/data") }
+            val firstBody = runBlocking { first.bodyAsText() }
+            assertEquals(HttpStatusCode.OK, first.status)
+            assertEquals("""{"name":"hello","count":42}""", firstBody)
+            assertEquals(etag, first.headers["ETag"])
+            assertEquals("private, max-age=60", first.headers["Cache-Control"])
+
+            // 条件付きGET：If-None-Match一致で304（Tier-A短絡、ボディなし）
+            val second = runBlocking {
+                client.get("http://localhost:$port/api/v1/plugins/sample/data") {
+                    header("If-None-Match", etag)
+                }
+            }
+            val secondBody = runBlocking { second.bodyAsText() }
+            client.close()
+
+            assertEquals(HttpStatusCode.NotModified, second.status)
+            assertEquals(etag, second.headers["ETag"])
+            assertTrue(secondBody.isEmpty())
+        }
     }
 
     @Test

--- a/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/ResponseCachingJettyTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/ResponseCachingJettyTest.kt
@@ -1,0 +1,165 @@
+package party.morino.mineauth.core.web.telemetry
+
+import arrow.core.Either
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.java.Java
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.install
+import io.ktor.server.auth.*
+import io.ktor.server.engine.embeddedServer
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.jetty.jakarta.Jetty
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.*
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import party.morino.mineauth.api.http.CacheControl
+import party.morino.mineauth.api.http.ConditionalRequest
+import party.morino.mineauth.api.http.Response
+import party.morino.mineauth.core.plugin.annotation.EndpointAccess
+import party.morino.mineauth.core.plugin.annotation.EndpointMetadata
+import party.morino.mineauth.core.plugin.annotation.HttpMethodType
+import party.morino.mineauth.core.plugin.annotation.ParameterInfo
+import party.morino.mineauth.core.plugin.annotation.PathSegment
+import party.morino.mineauth.core.plugin.dispatch.NamespaceTable
+import party.morino.mineauth.core.plugin.dispatch.PluginEndpointDispatcher
+import party.morino.mineauth.core.plugin.execution.ExecutionError
+import party.morino.mineauth.core.plugin.execution.MethodExecutionHandler
+import party.morino.mineauth.core.plugin.execution.MethodExecutionHandlerFactory
+import party.morino.mineauth.core.plugin.route.AuthenticationHandler
+import party.morino.mineauth.core.plugin.route.ParameterResolver
+import party.morino.mineauth.core.plugin.route.RouteExecutor
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.Serializable
+import kotlin.reflect.typeOf
+
+/**
+ * issue #375: Responseラッパーによるキャッシュヘッダー・条件付き304の実Jetty統合テスト
+ */
+class ResponseCachingJettyTest {
+
+    @Serializable
+    data class Payload(val value: String)
+
+    private val etag = "\"payload-v1\""
+
+    /**
+     * 条件付きGETハンドラーを模したディスパッチャを構築する
+     * ETagを持つResponse.Okを返し、If-None-Match一致時はハンドラー自身がNotModifiedを返す（Tier-B）
+     */
+    private fun buildDispatcher(computed: MutableList<String>): PluginEndpointDispatcher {
+        val endpoint = EndpointMetadata(
+            method = Dummy::handle,
+            handlerInstance = Dummy(),
+            path = "/data",
+            pathSegments = listOf(PathSegment.Literal("data")),
+            httpMethod = HttpMethodType.GET,
+            access = EndpointAccess.Public(null),
+            parameters = listOf(ParameterInfo.Conditional),
+            isSuspending = false,
+            responseType = typeOf<Payload>(),
+            returnsEither = false,
+            responseResolvableByCore = true,
+            returnsResponse = true
+        )
+        val executor = RouteExecutor(
+            ParameterResolver(Json),
+            object : MethodExecutionHandlerFactory {
+                override fun createHandler(metadata: EndpointMetadata): MethodExecutionHandler =
+                    object : MethodExecutionHandler {
+                        override suspend fun execute(
+                            metadata: EndpointMetadata,
+                            resolvedParams: List<Any?>
+                        ): Either<ExecutionError, Any?> {
+                            // 注入されたConditionalRequestで安価にETagを比較（Tier-B: ボディ生成前に短絡）
+                            val cond = resolvedParams.filterIsInstance<ConditionalRequest>().first()
+                            if (cond.isNoneMatch(etag)) {
+                                return Either.Right(Response.notModified(etag, CacheControl.maxAge(60)))
+                            }
+                            // 高価なボディ生成（テストでは計測用に記録）
+                            computed.add("built")
+                            return Either.Right(
+                                Response.of(Payload("hello"), etag = etag, cacheControl = CacheControl.maxAge(60))
+                            )
+                        }
+                    }
+            }
+        )
+        return PluginEndpointDispatcher(executor, AuthenticationHandler()).apply {
+            install("sample", NamespaceTable("SamplePlugin", "/api/v1/plugins/sample", listOf(endpoint)))
+        }
+    }
+
+    private class Dummy {
+        fun handle(): String = "unused"
+    }
+
+    private fun <T> withServer(dispatcher: PluginEndpointDispatcher, block: (Int) -> T): T {
+        val server = embeddedServer(Jetty, port = 0) {
+            install(Authentication) { bearer("test-auth") { authenticate { null } } }
+            // 本番同様にContentNegotiationを入れる（core直列化パスで使用）
+            install(ContentNegotiation) { json(Json) }
+            routing {
+                authenticate("test-auth", strategy = AuthenticationStrategy.Optional) {
+                    route("/api/v1/plugins/{namespace}/{path...}") {
+                        handle { dispatcher.dispatch(call) }
+                    }
+                }
+            }
+        }
+        server.start(wait = false)
+        return try {
+            val port = runBlocking { server.engine.resolvedConnectors().first().port }
+            block(port)
+        } finally {
+            server.stop(0, 0, TimeUnit.SECONDS)
+        }
+    }
+
+    @Test
+    @DisplayName("First GET returns 200 with ETag and Cache-Control")
+    fun firstGetHasCacheHeaders() {
+        val computed = mutableListOf<String>()
+        withServer(buildDispatcher(computed)) { port ->
+            val client = HttpClient(Java)
+            val response = runBlocking { client.get("http://localhost:$port/api/v1/plugins/sample/data") }
+            val body = runBlocking { response.bodyAsText() }
+            client.close()
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(etag, response.headers["ETag"])
+            assertEquals("private, max-age=60", response.headers["Cache-Control"])
+            assertEquals("""{"value":"hello"}""", body)
+            assertEquals(1, computed.size) // ボディが生成された
+        }
+    }
+
+    @Test
+    @DisplayName("Matching If-None-Match yields 304 and skips body computation")
+    fun conditionalGetReturns304() {
+        val computed = mutableListOf<String>()
+        withServer(buildDispatcher(computed)) { port ->
+            val client = HttpClient(Java)
+            val response = runBlocking {
+                client.get("http://localhost:$port/api/v1/plugins/sample/data") {
+                    header("If-None-Match", etag)
+                }
+            }
+            val body = runBlocking { response.bodyAsText() }
+            client.close()
+
+            assertEquals(HttpStatusCode.NotModified, response.status)
+            assertEquals(etag, response.headers["ETag"])
+            assertTrue(body.isEmpty()) // ボディなし
+            assertEquals(0, computed.size) // Tier-B: 高価なボディ生成はスキップされた
+        }
+    }
+}

--- a/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/ResponseCachingJettyTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/web/telemetry/ResponseCachingJettyTest.kt
@@ -17,7 +17,6 @@ import io.ktor.server.routing.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -139,6 +138,48 @@ class ResponseCachingJettyTest {
             assertEquals("private, max-age=60", response.headers["Cache-Control"])
             assertEquals("""{"value":"hello"}""", body)
             assertEquals(1, computed.size) // ボディが生成された
+        }
+    }
+
+    @Test
+    @DisplayName("Response.of honors a custom status")
+    fun customStatus() {
+        val endpoint = EndpointMetadata(
+            method = Dummy::handle,
+            handlerInstance = Dummy(),
+            path = "/created",
+            pathSegments = listOf(PathSegment.Literal("created")),
+            httpMethod = HttpMethodType.GET,
+            access = EndpointAccess.Public(null),
+            parameters = emptyList(),
+            isSuspending = false,
+            responseType = typeOf<Payload>(),
+            returnsEither = false,
+            responseResolvableByCore = true,
+            returnsResponse = true
+        )
+        val executor = RouteExecutor(
+            ParameterResolver(Json),
+            object : MethodExecutionHandlerFactory {
+                override fun createHandler(metadata: EndpointMetadata): MethodExecutionHandler =
+                    object : MethodExecutionHandler {
+                        override suspend fun execute(
+                            metadata: EndpointMetadata,
+                            resolvedParams: List<Any?>
+                        ): Either<ExecutionError, Any?> = Either.Right(
+                            Response.of(Payload("new"), status = party.morino.mineauth.api.http.HttpStatus.CREATED)
+                        )
+                    }
+            }
+        )
+        val dispatcher = PluginEndpointDispatcher(executor, AuthenticationHandler()).apply {
+            install("sample", NamespaceTable("SamplePlugin", "/api/v1/plugins/sample", listOf(endpoint)))
+        }
+        withServer(dispatcher) { port ->
+            val client = HttpClient(Java)
+            val response = runBlocking { client.get("http://localhost:$port/api/v1/plugins/sample/created") }
+            client.close()
+            assertEquals(HttpStatusCode.Created, response.status)
         }
     }
 

--- a/docs/content/docs/developer/addons/caching.mdx
+++ b/docs/content/docs/developer/addons/caching.mdx
@@ -1,0 +1,69 @@
+---
+title: Caching & Conditional Requests
+description: Set Cache-Control / ETag headers and answer conditional GETs with 304 Not Modified
+---
+
+Read-only endpoints often return data that changes rarely. MineAuth lets a handler attach cache headers and answer conditional requests so clients, reverse proxies, and CDNs can offload repeat traffic — and so the handler can skip recomputing an expensive body when nothing has changed.
+
+## 🧱 The `Response<T>` wrapper
+
+A handler may return its `@Serializable` DTO directly, or wrap it in `Response<T>` to attach an `ETag`, a `Cache-Control` directive, and extra headers. `Response` composes with `Either<HttpError, T>`.
+
+```kotlin
+@Get("/config")
+@Public
+suspend fun config(): Response<ConfigDto> =
+    Response.of(
+        loadConfig(),
+        etag = configEtag(),
+        cacheControl = CacheControl.maxAge(60)
+    )
+```
+
+`CacheControl` is a typed value object rather than a raw string:
+
+```kotlin
+CacheControl.maxAge(60)                                   // private, max-age=60
+CacheControl.maxAge(300, CacheControl.Visibility.PUBLIC)  // public, max-age=300
+CacheControl.NoStore                                       // no-store
+```
+
+Cache headers are applied only when the response is written successfully — a serialization failure or an `HttpError` never carries them.
+
+## ⚡ Conditional GET (304 Not Modified)
+
+To eliminate repeated work, inject a `ConditionalRequest` with `@Conditional`. The handler computes a **cheap** validator (a version number or timestamp) first, and returns `Response.notModified(...)` on a match — **before** loading or serializing the full body.
+
+```kotlin
+@Get("/shops/{id}")
+@Public
+suspend fun getShop(
+    @Path("id") id: String,
+    @Conditional cond: ConditionalRequest
+): Either<HttpError, Response<ShopDto>> = either {
+    // Cheap: fetch just a version/timestamp
+    val version = repo.versionOf(id) ?: raise(HttpError(HttpStatus.NOT_FOUND, "Shop not found"))
+    val etag = "\"shop-$id-$version\""
+
+    // If the client already has this version, skip the expensive load entirely
+    if (cond.isNoneMatch(etag)) return@either Response.notModified(etag, CacheControl.maxAge(60))
+
+    // Expensive: only reached on a cache miss
+    Response.of(repo.loadFull(id).toDto(), etag = etag, cacheControl = CacheControl.maxAge(60))
+}
+```
+
+Two levels of short-circuit apply:
+
+- **Body-computation skip** — the `@Conditional` check above lets the handler avoid loading and serializing the body at all. This is what removes the "re-read every file on every request" cost.
+- **Serialization skip** — even without `@Conditional`, if a `Response.of(...)` carries an `etag` and the GET request's `If-None-Match` matches, MineAuth returns `304` without serializing the already-built body.
+
+<Callout type="info">
+Keeping the ETag and the body consistent is the handler's responsibility. The simplest reliable pattern is to bump one monotonic version counter on every write that affects the response, and derive the ETag from it.
+</Callout>
+
+## 📋 Scope (v1)
+
+Supported now: `Cache-Control`, `ETag`, extra response headers, and conditional GET via `If-None-Match`.
+
+Not yet supported: `If-Modified-Since` / `Last-Modified`, `If-Match` / `412 Precondition Failed`, and a lazy body thunk (intentionally omitted — a lambda supplied by a shaded addon would cross the class-loader boundary the same way [issue #378](/docs/developer/addons/serialization) describes).

--- a/docs/content/docs/developer/addons/meta.json
+++ b/docs/content/docs/developer/addons/meta.json
@@ -5,7 +5,9 @@
 		"index",
 		"register-handler",
 		"annotations",
+		"caching",
 		"serialization",
+		"optional-dependency",
 		"authentication",
 		"examples"
 	]

--- a/docs/content/docs/developer/addons/optional-dependency.mdx
+++ b/docs/content/docs/developer/addons/optional-dependency.mdx
@@ -1,0 +1,74 @@
+---
+title: Optional Dependency (softDepend)
+description: Integrate with MineAuth as an optional dependency so your plugin still runs standalone
+---
+
+Most addons declare a hard `depend` on MineAuth. But a plugin that has its own standalone features (its own commands, its own data persistence) may want to integrate with MineAuth **only when it is present** — a `softDepend`. This page shows the correct pattern, and one trap to avoid.
+
+## ⚠️ Why the null check is not enough
+
+The obvious approach looks safe but is not:
+
+```kotlin
+// DON'T: crashes on enable when MineAuth is absent
+override fun onEnable() {
+    val api = MineAuthApi.get(server) ?: return  // never reached
+    api.register(this, "myplugin", MyHandler())
+}
+```
+
+With `compileOnly` on the API and `softDepend`, the `party.morino.mineauth.api.*` classes are provided **only** by MineAuth at runtime. When MineAuth is absent, calling `MineAuthApi.get(server)` forces the JVM to resolve the `MineAuthApi` class — which is nowhere on your classpath — and throws `NoClassDefFoundError` at the call site, **before** `get()` can return `null`. The graceful `?: return` is dead code.
+
+## ✅ The correct pattern
+
+Guard with a Bukkit-only plugin check first (this touches no MineAuth API class), and isolate all API usage in a **separate class** so the JVM does not resolve the API classes until after the guard passes.
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    compileOnly("party.morino.mineauth:api:1.0.0")
+}
+```
+
+```yaml
+# plugin.yml — optional, not required
+softdepend:
+  - MineAuth
+```
+
+```kotlin
+class MyPlugin : JavaPlugin() {
+    override fun onEnable() {
+        // 1. Bukkit-only check — references no MineAuth API class
+        if (server.pluginManager.getPlugin("MineAuth") != null) {
+            // 2. Delegate to a separate class so the API classes are only
+            //    resolved once we know MineAuth is present
+            MineAuthIntegration(this).register()
+        } else {
+            logger.info("MineAuth not present — HTTP endpoints disabled")
+        }
+    }
+}
+
+// Separate class: loaded lazily, only when the guard above passes
+class MineAuthIntegration(private val plugin: MyPlugin) {
+    fun register() {
+        val api = MineAuthApi.get(plugin.server) ?: return  // safe here
+        api.register(plugin, "myplugin", MyHandler())
+    }
+}
+```
+
+Here `MineAuthApi.get(...)` returning `null` is still meaningful: it covers the narrow load-ordering window where MineAuth is present but its service has not been registered yet.
+
+## 🔁 Hard depend (the default)
+
+If your plugin does not need to run without MineAuth, a hard `depend` is simpler — MineAuth is guaranteed to be loaded first, so `MineAuthApi.get(server)` is always safe and the null branch only guards against the service-registration window.
+
+```yaml
+# plugin.yml
+depend:
+  - MineAuth
+```
+
+This is what the bundled addons use. See [Addon Development](/docs/developer/addons) for the full quick-start.


### PR DESCRIPTION
Implements #375 and audits for standalone/softDepend breaks beyond #378 (now on master via #379).

## Issue #375 — response headers & conditional 304

Handlers can attach cache headers and answer conditional GETs:

- **`Response<T>` wrapper** (`Response.of` / `Response.notModified`) carrying `ETag`, `CacheControl`, and extra headers. Composes with `Either<HttpError, Response<T>>`.
- **`CacheControl`** typed value (`maxAge`, `NoStore`, visibility).
- **Injected `@Conditional ConditionalRequest`** exposing `If-None-Match`.

### True 304 short-circuit (two tiers)

- **Body-computation skip (Tier-B)** — the handler computes a *cheap* ETag (a version/timestamp) via `@Conditional` **before** loading the full body, and returns `Response.notModified(...)` on a match. This is what removes the "re-read all files every request" cost (the issue's headline). Proven by a test asserting the body builder never runs (`computed.size == 0`).
- **Serialization skip (Tier-A)** — for any `Response.of(dto, etag=...)`, a matching `If-None-Match` on a GET returns 304 without serializing.

### Design notes

- `Response` is a MineAuth API type: compile-time-linked, provided at runtime, never shaded — returning it does **not** reproduce #378. Bodies are materialized values (no `() -> T` thunk crosses the classloader boundary), which is why a lazy body is intentionally deferred.
- Raw `@Serializable` DTO returns remain valid — `Response` is opt-in.
- Registration peels `Either<HttpError, Response<U>>` → `U`, so split-classloader serialization keeps operating on the real DTO.
- Cache headers apply only on the successful write (never on an `HttpError` or a serialization 500); consumer-supplied framing headers (Content-Type/-Length/Transfer-Encoding/Connection) are dropped.

## Standalone / softDepend audit

Two findings (each verified against the code):

- **SchemaGenerator (code fix)** — `hasAnnotation<Serializable>()` is an instanceof check against MineAuth's own `Serializable` class, so a shaded consumer's DTO schema silently degraded to a bare `{type: object}`. Now detects `@Serializable` / `@SerialName` by canonical FQN (classloader-independent), matching the #378 runtime fix.
- **softDepend NoClassDefFoundError (docs)** — `MineAuthApi.get()` forces resolution of the `MineAuthApi` class, so under `softDepend` + `compileOnly` with MineAuth absent it throws at the call site before returning null. The fix is guidance, not code: guard with a Bukkit-level `pluginManager.getPlugin("MineAuth")` check first and isolate API usage in a separate class. New `optional-dependency` guide + `MineAuthApi.get` KDoc caveat.

## Docs

- `addons/caching.mdx` — the caching / conditional-request API.
- `addons/optional-dependency.mdx` — correct softDepend integration pattern.
- `MineAuthApi.get` KDoc caveat.

## Tests

Real-Jetty end-to-end: 200 + ETag/Cache-Control, conditional GET → 304 with body-build skipped, custom status, and the #375 × #378 intersection (shaded `Response<T>` serializes via the consumer classloader with headers preserved, then 304). Registration-level tests for `Response<T>` unwrap and `@Conditional` validation. SchemaGenerator `@SerialName` remap under a split classloader. Only the 2 pre-existing MockBukkit `initializationError` failures remain (unrelated).

## Notes

Designed and audited with a multi-agent workflow (design panel + standalone audit), implemented and adversarially reviewed thereafter.