### PR TITLE
🐛 Accept regex patterns in redirect URI validation on client creation

### DIFF
--- a/core/src/main/kotlin/party/morino/mineauth/core/dialog/OAuthClientCreateHandler.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/dialog/OAuthClientCreateHandler.kt
@@ -105,12 +105,31 @@ object OAuthClientCreateHandler : KoinComponent {
 
     /**
      * リダイレクトURIの形式チェック
+     * 認可時の検証（OAuthValidation.validateRedirectUri）が正規表現パターンを
+     * サポートしているため、通常のURIに加えて正規表現パターンも受け付ける
      */
     private fun isValidRedirectUri(uri: String): Boolean {
-        return try {
+        // 通常のURIとしてパースできればOK（最も一般的なケース）
+        val isPlainUri = try {
             val parsed = URI(uri)
             // スキームとホストが存在することを確認
             parsed.scheme != null && parsed.host != null
+        } catch (e: Exception) {
+            false
+        }
+        if (isPlainUri) {
+            return true
+        }
+
+        // 正規表現パターンとして受け付ける場合は、オープンリダイレクトを防ぐため
+        // http(s)スキームで始まるパターンのみ許可する（先頭の^は任意）
+        if (!uri.removePrefix("^").startsWith("http")) {
+            return false
+        }
+        return try {
+            // 正規表現としてコンパイルできることを確認
+            Regex(uri)
+            true
         } catch (e: Exception) {
             false
         }

--- a/docs/content/docs/developer/web-integration.mdx
+++ b/docs/content/docs/developer/web-integration.mdx
@@ -201,6 +201,20 @@ After authentication, you can access user information including:
 
 See [Userinfo Endpoint](/docs/developer/oauth/userinfo) for more details.
 
+## Redirect URI Patterns
+
+The registered redirect URI is validated in two steps: an exact string match first, then as a regular expression. When used as a regular expression, `/.*` is appended to the registered value (or `.*` if it already ends with `/`), so sub-paths are allowed automatically.
+
+This is useful for platforms with per-deployment preview URLs, such as Cloudflare Workers:
+
+```
+https://(?:[0-9a-f]{8}-)?myapp\.example\.workers\.dev/api/auth/oauth2/callback/
+```
+
+- `(?:[0-9a-f]{8}-)?` matches the optional 8-character hex prefix of preview deployments, while still allowing the stable domain.
+- Ending the pattern with `/` means only `.*` is appended, so `.../callback/MineAuth` matches as a sub-path.
+- Regular expression patterns must start with `http` (an optional leading `^` is allowed); other schemes are rejected at registration time to prevent open redirects.
+
 ## Troubleshooting
 
 ### Common Issues
@@ -208,6 +222,7 @@ See [Userinfo Endpoint](/docs/developer/oauth/userinfo) for more details.
 **"Invalid redirect URI"**
 - Ensure the redirect URI in your application matches exactly what was registered in MineAuth
 - Check for trailing slashes
+- If you registered a regular expression pattern, remember that `/.*` is appended unless the pattern ends with `/` (see [Redirect URI Patterns](#redirect-uri-patterns))
 
 **"PKCE verification failed"**
 - Make sure `pkce: true` is set for Public clients


### PR DESCRIPTION
## Summary
- The OAuth client creation dialog rejected regex redirect URI patterns with "無効なリダイレクトURI形式です", even though `OAuthValidation.validateRedirectUri` (and the DB schema) support regex patterns.
- `isValidRedirectUri` now falls back to accepting a compilable regex pattern when the value is not a plain URI. Patterns must start with `http` (optional leading `^`) to prevent open redirects.
- Documented redirect URI pattern behavior (auto-appended `/.*`, Cloudflare Workers preview URL example) in `web-integration.mdx`.

## Test plan
- `./gradlew :core:compileKotlin` passes.
- `task build` fails on `WebServerIntegrationTest` with `NoClassDefFoundError: org.bukkit.Registry` (MockBukkit/Paper registry init), but this failure is pre-existing and reproduces on an unmodified tree.