### PR TITLE
✨ Add reuse grace period to refresh token rotation

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -52,6 +52,8 @@ dependencies {
     testImplementation(libs.paper.api)
     testImplementation(libs.kotlinx.serialization.json)
     testImplementation(libs.bundles.coroutines)
+    // コルーチンのテスト用（runTest / TestScheduler）
+    testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.bundles.exposed)
     testImplementation(libs.koin.core)
     testImplementation(libs.arrow.core)

--- a/core/src/main/kotlin/party/morino/mineauth/core/MineAuth.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/MineAuth.kt
@@ -30,6 +30,7 @@ import party.morino.mineauth.core.commands.parser.ServiceNameParser
 import party.morino.mineauth.core.file.load.FileUtils
 import party.morino.mineauth.core.integration.IntegrationInitializer
 import party.morino.mineauth.core.web.WebServer
+import party.morino.mineauth.core.web.router.auth.oauth.RefreshTokenResponseCache
 import party.morino.mineauth.core.web.router.common.server.PluginInfoService
 import party.morino.mineauth.core.web.router.common.server.PluginInfoServiceImpl
 
@@ -75,6 +76,8 @@ open class MineAuth: SuspendingJavaPlugin() {
             single<PluginDirectory> { PluginDirectoryImpl() }
             single { DatabaseConnector() }
             single<PluginInfoService> { PluginInfoServiceImpl() }
+            // リフレッシュトークンローテーションのreuse grace period用キャッシュ
+            single { RefreshTokenResponseCache() }
         }
 
         getOrNull() ?: GlobalContext.startKoin {

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/RefreshTokenResponseCache.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/RefreshTokenResponseCache.kt
@@ -1,0 +1,106 @@
+package party.morino.mineauth.core.web.router.auth.oauth
+
+import arrow.core.Either
+import arrow.core.left
+import kotlinx.coroutines.CompletableDeferred
+import party.morino.mineauth.core.web.components.auth.TokenData
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * リフレッシュトークンローテーションのレスポンスキャッシュ
+ *
+ * RFC 9700 (OAuth 2.0 Security BCP) Section 4.14.2 に基づく reuse grace period の実装。
+ * 旧リフレッシュトークンのtokenId（jti）をキーに発行済みトークンレスポンスをgrace期間だけ保持し、
+ * 同一リフレッシュトークンでの並行・直後の再リクエストには同じレスポンスを返す（べき等化）。
+ *
+ * これにより、ブラウザの複数タブや並列fetchによる同時リフレッシュが全員同じ新トークンを
+ * 受け取れるようになり、ローテーション競合による invalid_grant を解消する。
+ *
+ * grace期間経過後の再利用は従来どおり拒否されるため、
+ * 盗難検知としてのトークンローテーションの意味は維持される。
+ *
+ * @param gracePeriodMillis grace期間（ミリ秒）。この期間内の再利用に同一レスポンスを返す
+ * @param clock 現在時刻の取得関数（テストで時間を制御するために注入可能）
+ */
+class RefreshTokenResponseCache(
+    private val gracePeriodMillis: Long = DEFAULT_GRACE_PERIOD_MILLIS,
+    private val clock: () -> Long = System::currentTimeMillis
+) {
+    companion object {
+        // RFC 9700 Section 4.14.2 が言及する限定的な再利用許容のためのgrace期間
+        // 並行リフレッシュ競合の解消には十分で、盗難トークンの悪用窓を最小限に抑える長さ
+        const val DEFAULT_GRACE_PERIOD_MILLIS = 60_000L
+    }
+
+    /**
+     * キャッシュエントリ
+     * deferredにより「発行中」の状態を表現でき、並行リクエストは同じ発行結果を待機できる
+     */
+    private class Entry(
+        val deferred: CompletableDeferred<Either<TokenRotationFailure, TokenData>>,
+        val createdAt: Long
+    )
+
+    // 旧tokenId（jti） → 発行結果のマップ
+    private val cache = ConcurrentHashMap<String, Entry>()
+
+    /**
+     * tokenIdに対応する発行済みレスポンスを取得するか、なければ発行処理を実行する
+     *
+     * 同一tokenIdへの並行呼び出しはputIfAbsentで単一の発行処理に集約され（シングルフライト）、
+     * 敗者は勝者の発行結果を待機して同じレスポンスを受け取る。
+     * 発行成功時はgrace期間だけ結果を保持し、期間内の後続リクエストにも同じレスポンスを返す。
+     * 発行失敗時は結果をキャッシュせず、次のリクエストで再試行できるようにする。
+     *
+     * @param tokenId 旧リフレッシュトークンのJWT ID（署名検証済みのjti claim）
+     * @param issue トークン発行処理（tokenIdごとに最初の1リクエストのみ実行される）
+     * @return 発行結果（成功時はTokenData、失敗時はTokenRotationFailure）
+     */
+    suspend fun getOrIssue(
+        tokenId: String,
+        issue: suspend () -> Either<TokenRotationFailure, TokenData>
+    ): Either<TokenRotationFailure, TokenData> {
+        // リクエスト契機でgrace期間を過ぎたエントリを削除（遅延クリーンアップ）
+        cleanupExpired()
+
+        val newEntry = Entry(CompletableDeferred(), clock())
+        val existing = cache.putIfAbsent(tokenId, newEntry)
+        if (existing != null) {
+            // grace期間内の再利用: 発行済み（または発行中）のレスポンスを共有する
+            return existing.deferred.await()
+        }
+
+        // 勝者として発行処理を実行する
+        val result = try {
+            issue()
+        } catch (e: Throwable) {
+            // 発行中の例外（リクエストのキャンセル含む）ではエントリを削除して再試行可能にし、
+            // 待機中の並行リクエストはserver_errorで解放する
+            // （例外をそのままdeferredに渡すと待機側のリクエストまで巻き込んでキャンセルされるため）
+            cache.remove(tokenId)
+            newEntry.deferred.complete(
+                TokenRotationFailure(OAuthErrorCode.SERVER_ERROR, "Failed to rotate refresh token").left()
+            )
+            throw e
+        }
+
+        if (result.isLeft()) {
+            // 失敗はキャッシュしない: エントリを削除してから完了させ、
+            // 待機明けに再試行するリクエストが死んだエントリに合流しないようにする
+            cache.remove(tokenId)
+        }
+        newEntry.deferred.complete(result)
+        return result
+    }
+
+    /**
+     * grace期間を過ぎた完了済みエントリを削除する
+     * 発行中（未完了）のエントリは重複発行を防ぐため削除しない
+     */
+    private fun cleanupExpired() {
+        val now = clock()
+        cache.entries.removeIf { (_, entry) ->
+            entry.deferred.isCompleted && now - entry.createdAt > gracePeriodMillis
+        }
+    }
+}

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/TokenRotationFailure.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/TokenRotationFailure.kt
@@ -1,0 +1,13 @@
+package party.morino.mineauth.core.web.router.auth.oauth
+
+/**
+ * リフレッシュトークンローテーションの失敗情報
+ * OAuthエラーコードとメッセージを保持し、呼び出し元でレスポンスに変換する
+ *
+ * @param errorCode OAuthエラーコード（invalid_grant, server_error等）
+ * @param message エラーの詳細メッセージ
+ */
+data class TokenRotationFailure(
+    val errorCode: OAuthErrorCode,
+    val message: String
+)

--- a/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/TokenRouter.kt
+++ b/core/src/main/kotlin/party/morino/mineauth/core/web/router/auth/oauth/TokenRouter.kt
@@ -1,6 +1,8 @@
 package party.morino.mineauth.core.web.router.auth.oauth
 
 import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
 import com.auth0.jwt.JWT
 import io.ktor.http.*
 import io.ktor.server.request.*
@@ -31,6 +33,8 @@ import java.util.*
 
 object TokenRouter: KoinComponent {
     val plugin: MineAuth by inject()
+    // RFC 9700 Section 4.14.2: reuse grace period用のレスポンスキャッシュ
+    private val refreshTokenResponseCache: RefreshTokenResponseCache by inject()
     private const val EXPIRES_IN = 300
     // RFC 6749 Section 4.1.2: 認可コードの最大有効期間（10分推奨）
     private const val AUTHORIZATION_CODE_LIFETIME_MS = 10 * 60 * 1000L
@@ -99,35 +103,61 @@ object TokenRouter: KoinComponent {
                         return@withSpan
                     }
 
-                    // RFC 6749 Section 10.4: リフレッシュトークンローテーション
-                    // 旧トークンの失効を先に行い、失敗時はトークン発行を中止する
-                    val rotated = withSpan("oauth.refresh_token.rotate") {
-                        revokeOldRefreshToken(verified.tokenId, verified.expiresAt, clientId)
-                    }
-                    if (!rotated) {
-                        call.respondOAuthError(OAuthErrorCode.SERVER_ERROR, "Failed to rotate refresh token")
-                        return@withSpan
-                    }
-                    val token = withSpan("jwt.issue", attributes = tokenTypeAttributes("access")) {
-                        issueToken(verified.authorizedData, clientId)
-                    }
-                    val newRefreshToken = withSpan("jwt.issue", attributes = tokenTypeAttributes("refresh")) {
-                        issueRefreshToken(verified.authorizedData, clientId)
+                    // RFC 9700 Section 4.14.2: reuse grace period 付きローテーション
+                    // 同一リフレッシュトークンでの並行・grace期間内のリクエストには
+                    // キャッシュ済みの同一レスポンスを返す（べき等化）
+                    // 実際のローテーションと発行はtokenIdごとに最初の1リクエストのみが実行する
+                    val result = refreshTokenResponseCache.getOrIssue(verified.tokenId) {
+                        // RFC 7009: 失効済みトークンの拒否
+                        // キャッシュ未ヒット（= grace期間外またはローテーション以外での失効）のみ到達するため、
+                        // /revokeで明示的に失効されたトークンやgrace期間経過後の再利用はここで拒否される
+                        if (RevokedTokenRepository.isRevoked(verified.tokenId)) {
+                            return@getOrIssue TokenRotationFailure(
+                                OAuthErrorCode.INVALID_GRANT, "Invalid or expired refresh token"
+                            ).left()
+                        }
+
+                        // RFC 6749 Section 10.4: リフレッシュトークンローテーション
+                        // 旧トークンの失効を先に行い、失敗時はトークン発行を中止する
+                        val rotated = withSpan("oauth.refresh_token.rotate") {
+                            revokeOldRefreshToken(verified.tokenId, verified.expiresAt, clientId)
+                        }
+                        if (!rotated) {
+                            return@getOrIssue TokenRotationFailure(
+                                OAuthErrorCode.SERVER_ERROR, "Failed to rotate refresh token"
+                            ).left()
+                        }
+                        val token = withSpan("jwt.issue", attributes = tokenTypeAttributes("access")) {
+                            issueToken(verified.authorizedData, clientId)
+                        }
+                        val newRefreshToken = withSpan("jwt.issue", attributes = tokenTypeAttributes("refresh")) {
+                            issueRefreshToken(verified.authorizedData, clientId)
+                        }
+
+                        // refresh_token使用時はID Tokenを発行しない（OIDC一般慣行）
+                        // ID Tokenはユーザー認証を表し、refresh_tokenはセッション継続のみ
+                        TokenData(
+                            accessToken = token,
+                            tokenType = "Bearer",
+                            expiresIn = EXPIRES_IN,
+                            refreshToken = newRefreshToken,
+                            idToken = null,
+                            scope = verified.authorizedData.scope
+                        ).right()
                     }
 
-                    // refresh_token使用時はID Tokenを発行しない（OIDC一般慣行）
-                    // ID Tokenはユーザー認証を表し、refresh_tokenはセッション継続のみ
-                    // RFC 6749 Section 5.1: トークンレスポンスにキャッシュ禁止ヘッダーを付与
-                    call.response.header(HttpHeaders.CacheControl, "no-store")
-                    call.response.header(HttpHeaders.Pragma, "no-cache")
-                    call.respond(HttpStatusCode.OK, TokenData(
-                        accessToken = token,
-                        tokenType = "Bearer",
-                        expiresIn = EXPIRES_IN,
-                        refreshToken = newRefreshToken,
-                        idToken = null,
-                        scope = verified.authorizedData.scope
-                    ))
+                    when (result) {
+                        is Either.Left -> {
+                            call.respondOAuthError(result.value.errorCode, result.value.message)
+                        }
+                        is Either.Right -> {
+                            // RFC 6749 Section 5.1: トークンレスポンスにキャッシュ禁止ヘッダーを付与
+                            // （キャッシュヒット時のレスポンスにも同じヘッダーを付与する）
+                            call.response.header(HttpHeaders.CacheControl, "no-store")
+                            call.response.header(HttpHeaders.Pragma, "no-cache")
+                            call.respond(HttpStatusCode.OK, result.value)
+                        }
+                    }
                 }else if (grantType == "authorization_code") {
                     //authorization_codeの処理 https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
                     // 期限切れ認可コードの遅延クリーンアップ（リクエスト契機で実行）
@@ -288,10 +318,9 @@ object TokenRouter: KoinComponent {
             val tokenId = jwt.id ?: return null
             val expiresAt = jwt.expiresAt ?: return null
 
-            // RFC 7009: トークンが失効済みかチェック
-            if (RevokedTokenRepository.isRevokedBlocking(tokenId)) {
-                return null
-            }
+            // 注: 失効チェックはここでは行わない
+            // grace期間内の再利用（レスポンスキャッシュヒット）を許可するため、
+            // 失効チェックはRefreshTokenResponseCacheのキャッシュ未ヒット時のみ実行される
 
             // クレームを取得してAuthorizedDataを構築（必須クレームの欠如はinvalid_grant扱い）
             val clientId = jwt.getClaim("client_id").asString() ?: return null

--- a/core/src/test/kotlin/party/morino/mineauth/core/MineAuthTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/MineAuthTest.kt
@@ -21,6 +21,7 @@ import party.morino.mineauth.core.file.data.ObservabilityConfig
 import party.morino.mineauth.core.file.data.WebServerConfigData
 import party.morino.mineauth.core.mocks.config.PluginDirectoryMock
 import party.morino.mineauth.core.plugin.pluginModule
+import party.morino.mineauth.core.web.router.auth.oauth.RefreshTokenResponseCache
 
 /**
  * MineAuthのテスト用拡張機能
@@ -74,6 +75,8 @@ class MineAuthTest :
                 )
             }
             single<ServerMock> { server }
+            // リフレッシュトークンローテーションのreuse grace period用キャッシュ
+            single { RefreshTokenResponseCache() }
         }
 
         // Koinを初期化（appModuleとpluginModuleを読み込む）

--- a/core/src/test/kotlin/party/morino/mineauth/core/web/router/auth/oauth/RefreshTokenResponseCacheTest.kt
+++ b/core/src/test/kotlin/party/morino/mineauth/core/web/router/auth/oauth/RefreshTokenResponseCacheTest.kt
@@ -1,0 +1,154 @@
+package party.morino.mineauth.core.web.router.auth.oauth
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import party.morino.mineauth.core.web.components.auth.TokenData
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * RefreshTokenResponseCacheのテスト
+ * reuse grace period（RFC 9700 Section 4.14.2）の主要分岐を検証する
+ */
+class RefreshTokenResponseCacheTest {
+
+    // テスト用のトークンレスポンスを生成する
+    private fun tokenData(marker: String) = TokenData(
+        accessToken = "access-$marker",
+        tokenType = "Bearer",
+        expiresIn = 300,
+        refreshToken = "refresh-$marker",
+        idToken = null,
+        scope = "openid"
+    )
+
+    @Test
+    @DisplayName("Concurrent requests with same tokenId share a single issuance")
+    fun concurrentRequestsShareSingleIssuance() = runTest {
+        val cache = RefreshTokenResponseCache(gracePeriodMillis = 60_000L, clock = { 0L })
+        val issueCount = AtomicInteger(0)
+        // 発行処理を待機させて並行リクエストを再現するためのゲート
+        val gate = CompletableDeferred<Unit>()
+
+        // 4本の並行リクエスト（moripathの実例と同じ構図）
+        val requests = (1..4).map {
+            async {
+                cache.getOrIssue("token-a") {
+                    issueCount.incrementAndGet()
+                    gate.await()
+                    tokenData("winner").right()
+                }
+            }
+        }
+        gate.complete(Unit)
+        val results = requests.awaitAll()
+
+        // 発行処理は1回のみ実行され、全員が同じレスポンスを受け取る
+        assertEquals(1, issueCount.get())
+        results.forEach { result ->
+            assertEquals(tokenData("winner").right(), result)
+        }
+    }
+
+    @Test
+    @DisplayName("Reuse within grace period returns cached response")
+    fun reuseWithinGracePeriodReturnsCachedResponse() = runTest {
+        var now = 0L
+        val cache = RefreshTokenResponseCache(gracePeriodMillis = 60_000L, clock = { now })
+
+        val first = cache.getOrIssue("token-a") { tokenData("first").right() }
+        // grace期間内（59秒後）の再利用は同じレスポンスを返し、発行処理は実行されない
+        now = 59_000L
+        val second = cache.getOrIssue("token-a") { tokenData("second").right() }
+
+        assertEquals(first, second)
+    }
+
+    @Test
+    @DisplayName("Reuse after grace period runs issuance again")
+    fun reuseAfterGracePeriodRunsIssuanceAgain() = runTest {
+        var now = 0L
+        val cache = RefreshTokenResponseCache(gracePeriodMillis = 60_000L, clock = { now })
+
+        cache.getOrIssue("token-a") { tokenData("first").right() }
+        // grace期間経過後はエントリが削除され、発行処理が再度実行される
+        // （実際のフローではこの発行処理内の失効チェックがinvalid_grantを返す）
+        now = 61_000L
+        val second = cache.getOrIssue("token-a") { tokenData("second").right() }
+
+        assertEquals(tokenData("second").right(), second)
+    }
+
+    @Test
+    @DisplayName("Failure is not cached and next request retries")
+    fun failureIsNotCachedAndNextRequestRetries() = runTest {
+        val cache = RefreshTokenResponseCache(gracePeriodMillis = 60_000L, clock = { 0L })
+        val failure = TokenRotationFailure(OAuthErrorCode.SERVER_ERROR, "Failed to rotate refresh token")
+
+        val first = cache.getOrIssue("token-a") { failure.left() }
+        // 失敗はキャッシュされず、次のリクエストで発行処理が再試行される
+        val second = cache.getOrIssue("token-a") { tokenData("retry").right() }
+
+        assertEquals(failure.left(), first)
+        assertEquals(tokenData("retry").right(), second)
+    }
+
+    @Test
+    @DisplayName("Exception during issuance releases waiters with server_error")
+    fun exceptionDuringIssuanceReleasesWaiters() = runTest {
+        val cache = RefreshTokenResponseCache(gracePeriodMillis = 60_000L, clock = { 0L })
+        val gate = CompletableDeferred<Unit>()
+
+        // 勝者の発行処理は例外で失敗する
+        val winner = async {
+            runCatching {
+                cache.getOrIssue("token-a") {
+                    gate.await()
+                    throw IllegalStateException("boom")
+                }
+            }
+        }
+        // 敗者は勝者の結果を待機する
+        val waiter = async {
+            cache.getOrIssue("token-a") {
+                // 勝者が先にエントリを登録しているため、この発行処理は実行されない
+                tokenData("unexpected").right()
+            }
+        }
+        // 勝者・敗者の両方をサスペンド地点まで進めてからゲートを開放する
+        // （勝者がエントリ登録済み・敗者が待機中の状態を確実に作る）
+        testScheduler.runCurrent()
+        gate.complete(Unit)
+
+        // 勝者には例外が伝播し、待機者はserver_errorで解放される
+        assertTrue(winner.await().isFailure)
+        val waiterResult = waiter.await()
+        assertTrue(waiterResult is Either.Left)
+        assertEquals(OAuthErrorCode.SERVER_ERROR, (waiterResult as Either.Left).value.errorCode)
+
+        // エントリは削除済みのため、次のリクエストで再試行できる
+        val retry = cache.getOrIssue("token-a") { tokenData("retry").right() }
+        assertEquals(tokenData("retry").right(), retry)
+    }
+
+    @Test
+    @DisplayName("Different tokenIds are issued independently")
+    fun differentTokenIdsAreIssuedIndependently() = runTest {
+        val cache = RefreshTokenResponseCache(gracePeriodMillis = 60_000L, clock = { 0L })
+
+        val a = cache.getOrIssue("token-a") { tokenData("a").right() }
+        val b = cache.getOrIssue("token-b") { tokenData("b").right() }
+
+        // tokenIdごとに独立して発行される
+        assertEquals(tokenData("a").right(), a)
+        assertEquals(tokenData("b").right(), b)
+    }
+}

--- a/docs/content/docs/developer/oauth/meta.json
+++ b/docs/content/docs/developer/oauth/meta.json
@@ -1,5 +1,12 @@
 {
 	"title": "OAuth / OIDC",
 	"icon": "KeyRound",
-	"pages": ["discovery", "scopes", "userinfo", "revoke", "error-responses"]
+	"pages": [
+		"discovery",
+		"scopes",
+		"userinfo",
+		"refresh-token-rotation",
+		"revoke",
+		"error-responses"
+	]
 }

--- a/docs/content/docs/developer/oauth/refresh-token-rotation.mdx
+++ b/docs/content/docs/developer/oauth/refresh-token-rotation.mdx
@@ -1,0 +1,72 @@
+---
+title: Refresh Token Rotation
+description: Refresh token rotation and reuse grace period based on RFC 9700
+---
+
+MineAuth rotates refresh tokens on every use. When a client exchanges a refresh token at the token endpoint, the old refresh token is revoked and a new access token / refresh token pair is issued. This limits the lifetime of a stolen refresh token to a single use.
+
+## Endpoint
+
+```
+POST /oauth2/token
+```
+
+### Example Request
+
+```http
+POST /oauth2/token HTTP/1.1
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=refresh_token&
+refresh_token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...&
+client_id=your-client-id&
+client_secret=your-client-secret
+```
+
+## Rotation Behavior
+
+Each successful refresh request performs the following steps:
+
+1. The refresh token's signature, expiration, and client binding are verified
+2. The old refresh token is added to the revocation list
+3. A new access token and a new refresh token are issued
+
+Clients must always store the refresh token returned in the latest response and discard the old one.
+
+## Reuse Grace Period
+
+Concurrent refresh requests with the same refresh token occur naturally in browser environments, for example when multiple tabs or parallel API calls detect an expired access token at the same time. Without mitigation, only one of these requests would succeed and the others would fail with `invalid_grant`, potentially leaving the client with a revoked refresh token.
+
+To handle this, MineAuth implements a reuse grace period as described in [RFC 9700 (OAuth 2.0 Security Best Current Practice) Section 4.14.2](https://www.rfc-editor.org/rfc/rfc9700#section-4.14.2):
+
+- The response for each rotation is cached in memory for **60 seconds**, keyed by the old refresh token's JWT ID
+- Requests that reuse the same refresh token within the grace period receive **the same response** (the same new access token and refresh token) as the first request
+- Concurrent requests are collapsed into a single issuance, so rotation is performed exactly once per token
+
+This makes the refresh operation idempotent within the grace period. All concurrent callers receive an identical token pair, which also prevents cookie or storage conflicts on the client side.
+
+### After the Grace Period
+
+Reuse of a rotated refresh token after the grace period has elapsed is rejected with `invalid_grant`, preserving the theft-detection property of token rotation.
+
+```json
+{
+  "error": "invalid_grant",
+  "error_description": "Invalid or expired refresh token"
+}
+```
+
+### Interaction with Explicit Revocation
+
+Tokens revoked through the [revocation endpoint](/docs/developer/oauth/revoke) are not eligible for the grace period. The cached response only exists for tokens that were revoked as part of a rotation.
+
+## Implementation Notes
+
+- The response cache is held in memory and entries are removed after the grace period expires
+- Failed rotations are not cached, so a subsequent request can retry the rotation
+- The grace period replay returns the same `Cache-Control: no-store` headers as a normal token response
+
+## References
+
+- [RFC 9700 - Best Current Practice for OAuth 2.0 Security, Section 4.14.2](https://www.rfc-editor.org/rfc/rfc9700#section-4.14.2)
+- [RFC 6749 - The OAuth 2.0 Authorization Framework, Section 6](https://datatracker.ietf.org/doc/html/rfc6749#section-6)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ cloudPaper = { group = "org.incendo", name = "cloud-paper", version.ref = "cloud
 
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json-jvm", version.ref = "serialization" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core-jvm", version.ref = "coroutine" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutine" }
 
 mccoroutine-bukkit-api = { group = "com.github.shynixn.mccoroutine", name = "mccoroutine-bukkit-api", version.ref = "mccoroutine" }
 mccoroutine-bukkit-core = { group = "com.github.shynixn.mccoroutine", name = "mccoroutine-bukkit-core", version.ref = "mccoroutine" }


### PR DESCRIPTION
Closes #389

## Summary

Implements option 2 from the issue: a **response cache** that makes refresh token rotation idempotent within a short reuse grace period, as described in [RFC 9700 Section 4.14.2](https://www.rfc-editor.org/rfc/rfc9700#section-4.14.2).

## How it works

- New `RefreshTokenResponseCache` keyed by the old refresh token's JWT ID (`jti`), registered as a Koin single.
- **Single-flight issuance**: concurrent requests with the same refresh token are collapsed via `putIfAbsent` + `CompletableDeferred` — rotation and issuance run exactly once, and all concurrent callers receive the identical new token pair. This resolves the 1-winner-3-losers race from the moripath dashboard (`Promise.all` with 4 parallel refreshes).
- **Grace period (60s)**: requests reusing the same refresh token within the grace window receive the cached response. After the window, reuse is rejected with `invalid_grant` as before, preserving the theft-detection property of rotation.
- The revocation check moved out of `verifyAndDecodeRefreshToken` into the cache's issue lambda, so it only runs on cache miss. Tokens explicitly revoked via `/revoke` never enter the cache and are still rejected.
- Failures (revocation DB error, exceptions/cancellation) are **not cached**: the entry is removed so the next request retries, and waiters are released with `server_error` instead of being cancelled along with the winner.

## Accepted trade-off

A refresh token explicitly revoked via `/revoke` *after* a rotation can still be replayed from the cache within the 60s grace window. This is inherent to RFC 9700's grace-period concession and is documented in the new docs page.

## Testing

- New unit tests for `RefreshTokenResponseCache` covering single-flight issuance, grace-window reuse, expiry, failure non-caching, and waiter release on exception (uses `kotlinx-coroutines-test`, added as a test dependency).
- `task build`: all tests pass except `WebServerIntegrationTest` and `AnnotationProcessorTest`, which fail locally **on master too** (MockBukkit registry init error, "MockBukkit / MC version mismatch") — verified via stash; unrelated to this change.

## Docs

- New page `docs/content/docs/developer/oauth/refresh-token-rotation.mdx` describing rotation behavior and the reuse grace period.